### PR TITLE
Tiny change to get paths correct and ant tasks generating build directories

### DIFF
--- a/tools/readme.txt
+++ b/tools/readme.txt
@@ -3,10 +3,10 @@ View this document with tabs set to 4 characters.
 
 To compile Wyvern, use Java 8 and JUnit 4, and ant 1.9.0 (or higher).
 Eclipse version 4.3 with Java 8 support works, earlier versions will not.
-To compile, just run ant.
+To compile, just run `ant build`.
 
 To run Wyvern from the command line, make sure Java 8 is on your path.
-Add wyvern\tools\bin to your CLASSPATH, and run "java wyvern.tools.util.CLI filename.wyv"
+Add `wyvern\tools\build` to your CLASSPATH, and run "java wyvern.tools.util.CLI filename.wyv"
 
 
 PACKAGE DESCRIPTIONS


### PR DESCRIPTION
After running `ant` and having it successfully completing, without generating either a `bin` or a `build` directory a few times, I tried `ant build` and got it to generate the `build` directory.

Perhaps this is obvious to a seasoned Java developer, but to a neophyte to Java build systems like myself, adding this precision of documentation might be a nice touch ^.^