### PR TITLE
Evaluation supported

### DIFF
--- a/tools/src/wyvern/target/corewyvernIL/decl/DefDeclaration.java
+++ b/tools/src/wyvern/target/corewyvernIL/decl/DefDeclaration.java
@@ -34,7 +34,7 @@ public class DefDeclaration extends NamedDeclaration {
 
 	@Override
 	public String toString() {
-		return "DefDeclaration[" + getName() + "(...) : " + type + " = ...]";
+		return "DefDeclaration[" + getName() + "(...) : " + type + " = " + body + "]";
 	}
 	
 	public List<FormalArg> getFormalArgs() {

--- a/tools/src/wyvern/target/corewyvernIL/expression/New.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/New.java
@@ -90,10 +90,12 @@ public class New extends Expression {
 	public Value interpret(EvalContext ctx) {
 		// evaluate all decls
 		List<Declaration> ds = new LinkedList<Declaration>();
-		for (Declaration d : decls) {
+		for (Declaration d : decls) {;
 			Declaration newD = d.interpret(ctx);
 			ds.add(newD);
 		}
-		return new ObjectValue(ds, selfName, getExprType());
+		ObjectValue objValue = new ObjectValue(ds, selfName, getExprType());
+		objValue.captureContext(ctx); //capture eval context
+		return objValue;
 	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/ObjectValue.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/ObjectValue.java
@@ -6,15 +6,19 @@ import wyvern.target.corewyvernIL.decl.Declaration;
 import wyvern.target.corewyvernIL.decl.DeclarationWithRHS;
 import wyvern.target.corewyvernIL.decl.DefDeclaration;
 import wyvern.target.corewyvernIL.support.EvalContext;
+import wyvern.target.corewyvernIL.support.GenContext;
 import wyvern.target.corewyvernIL.type.ValueType;
 
 public class ObjectValue extends New implements Invokable {
+	EvalContext evalCtx = EvalContext.empty(); // captured eval context
+	
 	public ObjectValue(List<Declaration> decls, String selfName, ValueType exprType) {
 		super(decls, selfName, exprType);
 	}
 
 	@Override
 	public Value invoke(String methodName, List<Value> args, EvalContext ctx) {
+		ctx = ctx.combine(evalCtx);
 		EvalContext methodCtx = ctx;
 		DefDeclaration dd = (DefDeclaration) findDecl(methodName);
 		for (int i = 0; i < args.size(); ++i) {
@@ -27,5 +31,9 @@ public class ObjectValue extends New implements Invokable {
 	public Value getField(String fieldName, EvalContext ctx) {
 		DeclarationWithRHS decl = (DeclarationWithRHS) findDecl(fieldName);
 		return (Value) decl.getDefinition();
+	}
+
+	public void captureContext(EvalContext ctx) {
+		evalCtx = ctx;
 	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/Variable.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/Variable.java
@@ -70,7 +70,8 @@ public class Variable extends Expression implements Path {
 
 	@Override
 	public Value interpret(EvalContext ctx) {
-		return ctx.lookup(name);
+		Value exp =  ctx.lookup(name);
+		return exp;
 	}
 
 	@Override

--- a/tools/src/wyvern/target/corewyvernIL/support/EmptyValContext.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/EmptyValContext.java
@@ -7,4 +7,14 @@ public class EmptyValContext extends EvalContext {
 	public Value lookup(String varName) {
 		throw new RuntimeException("Variable " + varName + " not found");
 	}
+
+	@Override
+	public EvalContext combine(EvalContext ctx) {
+		return ctx;
+	}
+
+	@Override
+	public String endToString() {
+		return null;
+	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/support/EvalContext.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/EvalContext.java
@@ -10,9 +10,13 @@ public abstract class EvalContext {
 	
 	public abstract Value lookup(String varName);
 	
+	public abstract EvalContext combine(EvalContext ctx);
+	
 	public static EvalContext empty() {
 		return theEmpty;
 	}
 	
-	private static EvalContext theEmpty = new EmptyValContext(); 
+	private static EvalContext theEmpty = new EmptyValContext();
+
+	public abstract String endToString();
 }

--- a/tools/src/wyvern/target/corewyvernIL/support/VarEvalContext.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/VarEvalContext.java
@@ -22,4 +22,25 @@ public class VarEvalContext extends EvalContext {
 			return previous.lookup(varName);
 		}
 	}
+
+	@Override
+	public EvalContext combine(EvalContext ctx) {
+		if(ctx instanceof EmptyValContext) {
+			return this;
+		} else {
+			// must be VarEvalContext
+			VarEvalContext vCtx = (VarEvalContext) ctx;
+			return this.extend(vCtx.varName, vCtx.v).combine(vCtx.previous);
+		}
+	}
+	
+	@Override
+	public String toString() {
+		return "EvalContext[" + endToString();
+	}
+	
+	@Override
+	public String endToString() {
+		return varName  + " = " + v + ", " + previous.endToString();
+	}
 }

--- a/tools/src/wyvern/tools/typedAST/core/Sequence.java
+++ b/tools/src/wyvern/tools/typedAST/core/Sequence.java
@@ -351,9 +351,15 @@ public class Sequence implements CoreAST, Iterable<TypedAST> {
 		if (!ai.hasNext())
 			throw new RuntimeException("expected an expression in the list");
 		
-		return GenUtil.doGenModuleIL(ctx, ctx, ai, isModule);
+		Expression decl =  GenUtil.doGenModuleIL(ctx, ctx, ai, isModule);
+		return decl;
 	}
 
+	/**
+	 * A filter for the sequence </br>
+	 * Combines the sequential type and method declarations into a block </br>
+	 * @return return the sequence after combination.
+	 */
 	private Sequence combine() {
 		boolean recBlock = false;
 		Sequence normalSeq = new Sequence();


### PR DESCRIPTION
Evaluation is now supported for multiple modules.

In the test multipleModuleTest, genExp method can generate IL Expression from IL declarations generated from multiple modules. 

genExp generate Expression from Declarations by creating a sequence of let expression.

Then it can be typechecked and evaluated. To support dynamic scoping, a new field was added into Class ObjectValue so that it can store the context while interpreting from new statement. Furthermore, to support this, another method combine was added in EvalContext which can combine two EvalContext together into one. 