### PR TITLE
Add ILTests, replace RuntimeExceptions with ToolError.reportError

### DIFF
--- a/tools/src/wyvern/target/corewyvernIL/expression/FieldGet.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/FieldGet.java
@@ -19,6 +19,8 @@ import wyvern.target.corewyvernIL.support.View;
 import wyvern.target.corewyvernIL.type.ValueType;
 import wyvern.target.oir.OIRAST;
 import wyvern.target.oir.OIREnvironment;
+import wyvern.tools.errors.ErrorMessage;
+import wyvern.tools.errors.ToolError;
 
 public class FieldGet extends Expression implements Path {
 
@@ -50,9 +52,9 @@ public class FieldGet extends Expression implements Path {
 		ValueType vt = objectExpr.typeCheck(ctx);
 		DeclType dt = vt.findDecl(fieldName, ctx);
 		if (dt == null)
-			throw new RuntimeException("typechecking error: operation not found");
+			ToolError.reportError(ErrorMessage.VARIABLE_NOT_DECLARED, this, fieldName);
 		if (!(dt instanceof ValDeclType || dt instanceof VarDeclType))
-			throw new RuntimeException("typechecking error: can't treat a method or type member as a field");
+			ToolError.reportError(ErrorMessage.OPERATOR_DOES_NOT_APPLY, this, dt.getName());
 		this.setExprType(((DeclTypeWithResult)dt).getResultType(View.from(objectExpr, ctx)));
 		return getExprType();
 	}

--- a/tools/src/wyvern/target/corewyvernIL/expression/New.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/New.java
@@ -16,6 +16,8 @@ import wyvern.target.corewyvernIL.type.StructuralType;
 import wyvern.target.corewyvernIL.type.ValueType;
 import wyvern.target.oir.OIRAST;
 import wyvern.target.oir.OIREnvironment;
+import wyvern.tools.errors.ErrorMessage;
+import wyvern.tools.errors.ToolError;
 
 public class New extends Expression {
 	
@@ -84,6 +86,7 @@ public class New extends Expression {
 		StructuralType requiredT = t.getStructuralType(ctx);
 		StructuralType actualT = new StructuralType(selfName, dts);
 		if (!actualT.isSubtypeOf(requiredT, ctx)) {
+			ToolError.reportError(ErrorMessage.ASSIGNMENT_SUBTYPING, this);
 			throw new RuntimeException("typechecking error: not a subtype");
 		}
 		

--- a/tools/src/wyvern/tools/tests/ILTests.java
+++ b/tools/src/wyvern/tools/tests/ILTests.java
@@ -144,6 +144,7 @@ public class ILTests {
 	}
 	
 	@Test
+	@Category(CurrentlyBroken.class)
 	public void testVarFieldReadFromNonExistent() throws ParseException {
 		String input = "val obj = new\n"
 					 + "    var v : system.Int = 5\n"
@@ -183,6 +184,7 @@ public class ILTests {
 	}
 	
 	@Test
+	@Category(CurrentlyBroken.class)
 	public void testVarFieldWriteToNonExistent () throws ParseException {
 		String input = "val obj = new\n"
 					 + "    var v : system.Int = 3\n"
@@ -211,8 +213,19 @@ public class ILTests {
 		IntegerLiteral ten = new IntegerLiteral(10);
 		Assert.assertEquals(result, ten);
 	}
+	
+	@Test
+	public void testWriteToValField () throws ParseException {
+		String input = "val object = new \n"
+					 + "    val field : system.Int = 5 \n"
+					 + "object.field = 10\n";
+		ExpressionAST ast = (ExpressionAST) TestUtil.getNewAST(input);
+		GenContext genCtx = GenContext.empty().extend("system", new Variable("system"), null);
+		assertTypeCheckFails(ast, genCtx);
+	}
 
 	@Test
+	@Category(CurrentlyBroken.class)
 	public void testTypeDeclarations () throws ParseException {
 		String input = "resource type Doubler\n"
 					 + "    def double(argument : system.Int) : system.Int\n"

--- a/tools/src/wyvern/tools/tests/ILTests.java
+++ b/tools/src/wyvern/tools/tests/ILTests.java
@@ -2,12 +2,14 @@ package wyvern.tools.tests;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import wyvern.stdlib.Globals;
 import wyvern.target.corewyvernIL.decltype.DeclType;
 import wyvern.target.corewyvernIL.expression.Expression;
 import wyvern.target.corewyvernIL.expression.FieldGet;
@@ -24,6 +26,7 @@ import wyvern.target.corewyvernIL.support.TypeGenContext;
 import wyvern.target.corewyvernIL.support.Util;
 import wyvern.target.corewyvernIL.type.NominalType;
 import wyvern.target.corewyvernIL.type.ValueType;
+import wyvern.tools.errors.ErrorMessage;
 import wyvern.tools.errors.ToolError;
 import wyvern.tools.imports.extensions.WyvernResolver;
 import wyvern.tools.interop.FObject;
@@ -139,6 +142,17 @@ public class ILTests {
     	IntegerLiteral five = new IntegerLiteral(5);
 		Assert.assertEquals(five, v);
 	}
+	
+	@Test
+	public void testVarFieldReadFromNonExistent() throws ParseException {
+		String input = "val obj = new\n"
+					 + "    var v : system.Int = 5\n"
+					 + "obj.x\n";
+		GenContext genCtx = GenContext.empty().extend("system", new Variable("system"), null);
+		ExpressionAST ast = (ExpressionAST) TestUtil.getNewAST(input);
+		assertTypeCheckFails(ast, genCtx);
+	}
+	
 	@Test
 	public void testVarFieldWrite() throws ParseException {
 		String input = "val obj = new\n"
@@ -157,6 +171,65 @@ public class ILTests {
     	IntegerLiteral five = new IntegerLiteral(5);
 		Assert.assertEquals(five, v);
 	}
+	
+	@Test
+	public void testVarFieldWriteToWrongType() throws ParseException {
+		String input = "val obj = new\n"
+					 + "    var v : system.Int = 3\n"
+					 + "obj.v = \"hello\"\n";
+		ExpressionAST ast = (ExpressionAST) TestUtil.getNewAST(input);
+		GenContext genCtx = GenContext.empty().extend("system", new Variable("system"), null);
+		assertTypeCheckFails(ast, genCtx);
+	}
+	
+	@Test
+	public void testVarFieldWriteToNonExistent () throws ParseException {
+		String input = "val obj = new\n"
+					 + "    var v : system.Int = 3\n"
+					 + "obj.x = 5\n";
+		ExpressionAST ast = (ExpressionAST) TestUtil.getNewAST(input);
+		GenContext genCtx = GenContext.empty().extend("system", new Variable("system"), null);
+		assertTypeCheckFails(ast, genCtx);
+	}
+	
+	@Test
+	@Category(CurrentlyBroken.class)
+	public void testWriteFieldtoOtherField () throws ParseException {
+		// Need to declare a structural type T, then declare firstObj as var firstObj : T = new ...
+		String input = "val firstObj = new\n"
+					 + "    var a : system.Int = 5\n"
+				     + "val secondObj = new\n"
+				     + "    var b : system.Int = 10\n"
+				     + "firstObj.a = secondObj.b\n"
+				     + "firstObj.a";
+		ExpressionAST ast = (ExpressionAST) TestUtil.getNewAST(input);
+		GenContext genCtx = GenContext.empty().extend("system", new Variable("system"), null);
+		Expression program = ast.generateIL(genCtx);
+		ValueType type = program.typeCheck(TypeContext.empty());
+		Assert.assertEquals(Util.intType(), type);
+		Value result = program.interpret(EvalContext.empty());
+		IntegerLiteral ten = new IntegerLiteral(10);
+		Assert.assertEquals(result, ten);
+	}
+
+	@Test
+	public void testAssignStructuralTypes() throws ParseException {
+		String input = "val firstObj = new\n"
+					 + "    var a : system.Int = 10\n"
+					 + "val secondObj = new\n"
+					 + "    var b : system.Int = 20\n"
+					 + "firstObj = secondObj\n"
+					 + "firstObj.a\n";
+		ExpressionAST ast = (ExpressionAST) TestUtil.getNewAST(input);
+		GenContext genCtx = GenContext.empty().extend("system", new Variable("system"), null);
+		Expression program = ast.generateIL(genCtx);
+		ValueType type = program.typeCheck(TypeContext.empty());
+		Assert.assertEquals(Util.intType(), type);
+		Value result = program.interpret(EvalContext.empty());
+		IntegerLiteral twenty = new IntegerLiteral(20);
+		Assert.assertEquals(result, twenty);
+	}
+	
 	@Test
 	public void testDefDecl() throws ParseException {
 		String input = "val obj = new\n"
@@ -581,4 +654,19 @@ public class ILTests {
 			return Integer.toString(Integer.parseInt(s)+1);
 		}
 	}
+	
+
+	/**
+	 * Asserts that the given AST should not successfully typecheck and should throw 
+	 * some kind of ToolError.
+	 * @param ast: ast that should fail typechecking.
+	 */
+	private static void assertTypeCheckFails(ExpressionAST ast, GenContext genCtx) {
+		try {
+			Expression program = ast.generateIL(genCtx);
+			program.typeCheck(TypeContext.empty());
+			Assert.fail("A type error should have been reported.");
+		} catch (ToolError toolError) {}
+	}
+	
 }

--- a/tools/src/wyvern/tools/tests/ILTests.java
+++ b/tools/src/wyvern/tools/tests/ILTests.java
@@ -213,21 +213,21 @@ public class ILTests {
 	}
 
 	@Test
-	public void testAssignStructuralTypes() throws ParseException {
-		String input = "val firstObj = new\n"
-					 + "    var a : system.Int = 10\n"
-					 + "val secondObj = new\n"
-					 + "    var b : system.Int = 20\n"
-					 + "firstObj = secondObj\n"
-					 + "firstObj.a\n";
+	public void testTypeDeclarations () throws ParseException {
+		String input = "resource type Doubler\n"
+					 + "    def double(argument : system.Int) : system.Int\n"
+					 + "val d : Doubler = new\n"
+					 + "	def double (argument : system.Int) : system.Int\n"
+					 + "		argument * 2\n"
+					 + "d.double(5)";
 		ExpressionAST ast = (ExpressionAST) TestUtil.getNewAST(input);
 		GenContext genCtx = GenContext.empty().extend("system", new Variable("system"), null);
 		Expression program = ast.generateIL(genCtx);
 		ValueType type = program.typeCheck(TypeContext.empty());
 		Assert.assertEquals(Util.intType(), type);
 		Value result = program.interpret(EvalContext.empty());
-		IntegerLiteral twenty = new IntegerLiteral(20);
-		Assert.assertEquals(result, twenty);
+		IntegerLiteral ten = new IntegerLiteral(10);
+		Assert.assertEquals(result, ten);
 	}
 	
 	@Test


### PR DESCRIPTION
These commits do two things:
- Replace a bunch of the RuntimeExceptions thrown during typechecking with ToolError.reportError.
- Add a bunch of test cases in ILTests.

Many of the test cases are programs which are not well-typed and expect ToolErrors to be thrown. The purpose is to make sure the errors are reported at compile-time instead of run-time. The tests are:

##### testVarFieldRead (Passes)
The other test reads from a val declaration. This one reads from a var declaration.
##### testVarFieldWriteToWrongType (Passes)
Tries to write a String to a field declared as an Int. Appropriately throws a ToolError.
##### testWriteToValField (Passes)
Tries to write to an Int declared with val. Appropriately throws a ToolError.


##### testWriteFieldToOtherField (Broken)
Declares two objects with mutable Int fields. Tries to assign one Int field to the other. Currently gives a ClassCastException during interpretation.
##### testVarReadFromNonExistent (Broken)
This test tries to read from a non-existent field. It currently fails because a runtime exception is thrown in InvocationExprGenerator (not sure how to throw a ToolError from here?).
##### testTypeDeclarations (Broken)
Declares a custom type. Instantiates an object of that type and calls a method on the object. Throws a NullPointerException when generating the IL for the program.