### PR TITLE
Top-level Var Declarations, Reads, Writes

### DIFF
--- a/tools/src/wyvern/target/corewyvernIL/expression/FieldSet.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/FieldSet.java
@@ -88,8 +88,19 @@ public class FieldSet extends Expression {
 		if (!(decl instanceof wyvern.target.corewyvernIL.decl.VarDeclaration))
 			throw new RuntimeException("Expected assignment to var field in field set.");
 		VarDeclaration varDecl = (VarDeclaration) decl;
-		VarDeclaration varDeclUpdated = new VarDeclaration(fieldName, varDecl.getType(), exprToAssign);
-				
+		Value exprInterpreted = exprToAssign.interpret(ctx);
+		VarDeclaration varDeclUpdated = null;
+		
+		// Evaluate the expression in the current context. Update the declaration.
+		// VarDeclaration's constructor needs to take an expression, not a value.
+		// TODO: are these the only cases for what exprInterpreted can be?
+		if (exprInterpreted instanceof AbstractValue) {
+			varDeclUpdated = new VarDeclaration(fieldName, varDecl.getType(), (AbstractValue)exprInterpreted);
+		}
+		else {
+			ToolError.reportError(ErrorMessage.ASSIGNMENT_SUBTYPING, this);
+		}
+		
 		// Update object's declarations.
 		object.setDecl(varDeclUpdated);
 		return object;

--- a/tools/src/wyvern/target/corewyvernIL/support/EmptyGenContext.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/EmptyGenContext.java
@@ -31,5 +31,10 @@ public class EmptyGenContext extends GenContext {
 	public CallableExprGenerator getCallableExprRec(String varName, GenContext origCtx) {
 		throw new RuntimeException("Variable " + varName + " not found");
 	}
+	
+	@Override
+	public boolean isDefined (String varName) {
+		return false;
+	}
 
 }

--- a/tools/src/wyvern/target/corewyvernIL/support/GenContext.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/GenContext.java
@@ -105,4 +105,12 @@ public abstract class GenContext extends TypeContext {
 	public final CallableExprGenerator getCallableExpr(String varName) {
 		return getCallableExprRec(varName, this);
 	}
+	
+	/**
+	 * Check to see if the given variable name is defined in the context.
+	 * @param varName: name of variable to lookup.
+	 * @return true if the variable is defined.
+	 */
+	public abstract boolean isDefined (String varName);
+	
 }

--- a/tools/src/wyvern/target/corewyvernIL/support/MethodGenContext.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/MethodGenContext.java
@@ -55,4 +55,10 @@ public class MethodGenContext extends GenContext {
 			return genContext.getCallableExprRec(varName, origCtx);
 	}
 
+	@Override
+	public boolean isDefined(String varName) {
+		return genContext.isDefined(varName);
+	}
+	
+
 }

--- a/tools/src/wyvern/target/corewyvernIL/support/TypeGenContext.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/TypeGenContext.java
@@ -51,4 +51,9 @@ public class TypeGenContext extends GenContext {
 		return genContext.getCallableExprRec(varName, origCtx);
 	}
 
+	@Override
+	public boolean isDefined(String varName) {
+		return genContext.isDefined(varName);
+	}
+
 }

--- a/tools/src/wyvern/target/corewyvernIL/support/VarGenContext.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/VarGenContext.java
@@ -59,5 +59,11 @@ public class VarGenContext extends GenContext {
 		else {
 			return genContext.getCallableExprRec(varName, origCtx);
 		}
-	}	
+	}
+	
+	@Override
+	public boolean isDefined (String varName) {
+		return var.equals(varName) ? true : genContext.isDefined(varName);
+	}
+	
 }

--- a/tools/src/wyvern/tools/tests/ModuleSystemTests.java
+++ b/tools/src/wyvern/tools/tests/ModuleSystemTests.java
@@ -247,7 +247,6 @@ public class ModuleSystemTests {
 	}
 	
 	@Test
-	@Category(CurrentlyBroken.class)
 	public void testTopLevelVarsSimple () throws ParseException {
 		GenContext genCtx = GenContext.empty().extend("system", new Variable("system"), null);
 		genCtx = new TypeGenContext("Int", "system", genCtx);
@@ -271,7 +270,7 @@ public class ModuleSystemTests {
 		
 		// Evaluate.
 		wyvern.target.corewyvernIL.expression.Value result = program.interpret(EvalContext.empty());
-		Assert.assertEquals(new IntegerLiteral(10), result);
+		Assert.assertEquals(new IntegerLiteral(5), result);
 		
 	}
 	

--- a/tools/src/wyvern/tools/tests/ModuleSystemTests.java
+++ b/tools/src/wyvern/tools/tests/ModuleSystemTests.java
@@ -247,7 +247,7 @@ public class ModuleSystemTests {
 	}
 	
 	@Test
-	public void testTopLevelVarsSimple () throws ParseException {
+	public void testTopLevelVarGet () throws ParseException {
 		GenContext genCtx = GenContext.empty().extend("system", new Variable("system"), null);
 		genCtx = new TypeGenContext("Int", "system", genCtx);
 		genCtx = new TypeGenContext("Unit", "system", genCtx);
@@ -260,17 +260,37 @@ public class ModuleSystemTests {
 		Sequence seq = (Sequence) ast;
 		Expression program = seq.generateIL(genCtx);
 		
-		// Figure out the type of this code as a module, add to TypeContext.
-		ValueType vt = seq.figureOutType(genCtx);
-		TypeContext ctx = TypeContext.empty().extend("this", vt);
-		
 		// Typecheck. 
-		ValueType t = program.typeCheck(ctx);
+		ValueType t = program.typeCheck(GenContext.empty());
 		Assert.assertEquals(Util.intType(), t);
 		
 		// Evaluate.
 		wyvern.target.corewyvernIL.expression.Value result = program.interpret(EvalContext.empty());
 		Assert.assertEquals(new IntegerLiteral(5), result);
+		
+	}
+	
+	@Test
+	public void testTopLevelVarSet () throws ParseException {
+		GenContext genCtx = GenContext.empty().extend("system", new Variable("system"), null);
+		genCtx = new TypeGenContext("Int", "system", genCtx);
+		genCtx = new TypeGenContext("Unit", "system", genCtx);
+	
+		String source = "var v : Int = 5\n"
+					  + "v = 10\n"
+					  + "v\n";
+		
+		// Generate code to be evaluated.
+		ExpressionAST ast = (ExpressionAST) TestUtil.getNewAST(source);
+		Expression program = ast.generateIL(genCtx);
+		
+		// Typecheck. 
+		ValueType t = program.typeCheck(GenContext.empty());
+		Assert.assertEquals(Util.intType(), t);
+		
+		// Evaluate.
+		wyvern.target.corewyvernIL.expression.Value result = program.interpret(EvalContext.empty());
+		Assert.assertEquals(new IntegerLiteral(10), result);
 		
 	}
 	

--- a/tools/src/wyvern/tools/tests/ModuleSystemTests.java
+++ b/tools/src/wyvern/tools/tests/ModuleSystemTests.java
@@ -39,8 +39,10 @@ import wyvern.tools.tests.suites.CurrentlyBroken;
 import wyvern.tools.tests.suites.RegressionTests;
 import wyvern.tools.tests.tagTests.TestUtil;
 import wyvern.tools.typedAST.abs.Declaration;
+import wyvern.tools.typedAST.core.Sequence;
 import wyvern.tools.typedAST.core.binding.evaluation.EvaluationBinding;
 import wyvern.tools.typedAST.core.values.IntegerConstant;
+import wyvern.tools.typedAST.interfaces.ExpressionAST;
 import wyvern.tools.typedAST.interfaces.TypedAST;
 import wyvern.tools.typedAST.interfaces.Value;
 import wyvern.tools.types.Type;
@@ -215,6 +217,27 @@ public class ModuleSystemTests {
 		
 		// Should compile OK, but top-level vars not implemented yet.
 		// (21/12/2015)
+	}
+
+	@Test
+	@Category(CurrentlyBroken.class)
+	public void testTopLevelVars () throws ParseException {
+		
+		String[] fileList = {"Database.wyv", "DatabaseUser.wyv"};
+		GenContext genCtx = GenContext.empty().extend("system", new Variable("system"), null);
+
+		List<wyvern.target.corewyvernIL.decl.Declaration> decls = new LinkedList<wyvern.target.corewyvernIL.decl.Declaration>();
+		
+		for(String fileName : fileList) {
+			System.out.println(fileName);
+			String source = TestUtil.readFile(PATH + fileName);
+			TypedAST ast = TestUtil.getNewAST(source);
+			wyvern.target.corewyvernIL.decl.Declaration decl = ((Declaration) ast).topLevelGen(genCtx);
+			decls.add(decl);
+			genCtx = GenUtil.link(genCtx, decl);
+		}
+		
+		
 	}
 	
 }

--- a/tools/src/wyvern/tools/tests/modules/DatabaseUser.wyv
+++ b/tools/src/wyvern/tools/tests/modules/DatabaseUser.wyv
@@ -1,0 +1,5 @@
+
+require Database
+
+Database.contents = 10
+Database.contents

--- a/tools/src/wyvern/tools/typedAST/core/Sequence.java
+++ b/tools/src/wyvern/tools/typedAST/core/Sequence.java
@@ -395,50 +395,13 @@ public class Sequence extends AbstractExpressionAST implements CoreAST, Iterable
 	 * @return the IL expression of a module
 	 */
 	public Expression generateModuleIL(GenContext ctx, boolean isModule) {
-		
-		// Script preprocessing.
-		if (!isModule) {
-
-			// Figure out type of "this" to allow for self-referential statements.
-			ValueType moduleType = this.figureOutType(ctx);
-			ctx = ctx.extend("this", new Variable("this"), moduleType);
-			
-		}
-		TopLevelContext tlc = new TopLevelContext(ctx);
-		
-		// Generate module IL by looking at everything in sequence.
 		Sequence seqWithBlocks = combine();
+		TopLevelContext tlc = new TopLevelContext(ctx);
 		seqWithBlocks.genTopLevel(tlc);
 		Expression result = isModule?tlc.getModuleExpression():tlc.getExpression();
 		return result;
-		
 	}
 	
-	/**
-	 * Check to see whether execution of this sequence will capture or modify state.
-	 * @return boolean
-	 */
-	private boolean isStateful () {
-		for (TypedAST ast : exps) {
-			if (ast instanceof VarDeclaration || ast instanceof FieldSet) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	/**
-	 * Turn a sequence of code without a module into an anonymous module.
-	 * @param ctx: ctx to evaluate in.
-	 * @return a ModuleDeclaration.
-	 */
-	public ModuleDeclaration asHeadlessModule (GenContext ctx) {
-		boolean isResourceModule = this.isStateful();
-		String anonymousName = GenContext.generateName();
-		ModuleDeclaration moduleDecl = new ModuleDeclaration(anonymousName, (EnvironmentExtender)this, null, isResourceModule);
-		return moduleDecl;
-	}
-
 	@Override
 	public void genTopLevel(TopLevelContext tlc) {
 		for (TypedAST ast : exps) {

--- a/tools/src/wyvern/tools/typedAST/core/declarations/VarDeclaration.java
+++ b/tools/src/wyvern/tools/typedAST/core/declarations/VarDeclaration.java
@@ -182,7 +182,6 @@ public class VarDeclaration extends Declaration implements CoreAST {
 	
 	@Override
 	public void genTopLevel (TopLevelContext tlc) {
-
 		GenContext ctx = tlc.getContext();
 		
 		// Name and type of this variable.
@@ -195,17 +194,19 @@ public class VarDeclaration extends Declaration implements CoreAST {
 		ValueType valTypeOfVar = typeOfVar.getILType(ctx);	
 		
 		// Create the body of the anonymous object.
+	
+		// Internal name of anonymous object.
+		String anonName = tlc.anonymousObjectGenerate(varName);
+
+		// Body of anonymous object will be stored here.
 		List<Declaration> decls = new LinkedList<>();
 		decls.add(this);
 
-		// Object name and variable reference.
-		String objName = TopLevelContext.getAnonymousVarName(varName);
-		wyvern.tools.typedAST.core.expressions.Variable objReference =
-				new wyvern.tools.typedAST.core.expressions.Variable(new NameBindingImpl("this", null), null);
-		
-		// Create the getter declaration.
-		String getterName = "get";
-		Invocation getterBody = new Invocation(objReference, varName, null, null);
+		// Create a declaration for the anonymous object's getter.
+		String getterName = TopLevelContext.anonymousGetterName();
+		wyvern.tools.typedAST.core.expressions.Variable selfReference = new
+				wyvern.tools.typedAST.core.expressions.Variable(new NameBindingImpl("this", null), null);
+		Invocation getterBody = new Invocation(selfReference, varName, null, null);
 		DefDeclaration getterDecl = new DefDeclaration(getterName, typeOfVar, new LinkedList<>(),
 														 getterBody, false, null);
 		decls.add(getterDecl);
@@ -216,9 +217,9 @@ public class VarDeclaration extends Declaration implements CoreAST {
 		Expression expr = objInstantiation.generateIL(ctx);
 		ValueType objType = declSeq.figureOutType(ctx);
 		
-		GenContext newCtx = tlc.getContext().extend(objName, expr, objType);
+		GenContext newCtx = tlc.getContext().extend(anonName, expr, objType);
 		tlc.updateContext(newCtx);
-		tlc.addLet(objName, objType, expr, false);
+		tlc.addLet(anonName, objType, expr, false);
 		
 		/*
 		 * 

--- a/tools/src/wyvern/tools/typedAST/core/declarations/VarDeclaration.java
+++ b/tools/src/wyvern/tools/typedAST/core/declarations/VarDeclaration.java
@@ -236,15 +236,6 @@ public class VarDeclaration extends Declaration implements CoreAST {
 		tlc.updateContext(newCtx);
 		tlc.addLet(anonName, objType, expr, false);
 		
-		/*
-		 * 
-	public New(DeclSequence seq, FileLocation fileLocation) {
-		this.seq = seq;
-		this.location = fileLocation;
-	}
-
-		 */
-		
 	}
 	
 	@Override

--- a/tools/src/wyvern/tools/typedAST/core/declarations/VarDeclaration.java
+++ b/tools/src/wyvern/tools/typedAST/core/declarations/VarDeclaration.java
@@ -7,6 +7,7 @@ import wyvern.target.corewyvernIL.expression.Expression;
 import wyvern.target.corewyvernIL.expression.Let;
 import wyvern.target.corewyvernIL.expression.Variable;
 import wyvern.target.corewyvernIL.support.GenContext;
+import wyvern.target.corewyvernIL.support.TopLevelContext;
 import wyvern.target.corewyvernIL.type.ValueType;
 import wyvern.tools.errors.ErrorMessage;
 import wyvern.tools.errors.FileLocation;
@@ -161,9 +162,45 @@ public class VarDeclaration extends Declaration implements CoreAST {
 		return new wyvern.target.corewyvernIL.decl.VarDeclaration(getName(), binding.getType().getILType(ctx), definition.generateIL(ctx));
 	}
 
+	/**
+	 * Internal helper method. Return the ValueType of this definition. If the type isn't
+	 * currently set, it will figure it out and set the type.
+	 * @param ctx: ctx to evaulate.
+	 * @return the ValueType of the definition of this VarDeclaration.
+	 */
+	private ValueType getILValueType (GenContext ctx) {
+		if (definitionType == null)
+			definitionType = definition.getType();
+		return definitionType.getILType(ctx);
+	}
+	
+	@Override
+	public void genTopLevel (TopLevelContext tlc) {
+
+		// Create the var primitive and update the top-level context.
+		GenContext ctx = tlc.getContext();
+		String varName = getName();
+		ValueType varType = getILValueType(ctx);
+		Expression varExpr = this.definition.generateIL(ctx);
+		tlc.updateContext(ctx.extend(varName, varExpr, varType));
+		
+	}
+	
 	@Override
 	public wyvern.target.corewyvernIL.decl.Declaration topLevelGen(GenContext ctx) {
 		// TODO Auto-generated method stub
 		return null;
 	}
+
+	@Override
+	public void addModuleDecl(TopLevelContext tlc) {
+		GenContext ctx = tlc.getContext();
+		wyvern.target.corewyvernIL.decl.Declaration decl;
+		decl = new wyvern.target.corewyvernIL.decl.VarDeclaration(getName(),
+																  getILValueType(ctx),
+																  definition.generateIL(ctx));
+		DeclType dt = genILType(tlc.getContext());
+		tlc.addModuleDecl(decl,dt);		
+	}
+	
 }

--- a/tools/src/wyvern/tools/typedAST/core/declarations/VarDeclaration.java
+++ b/tools/src/wyvern/tools/typedAST/core/declarations/VarDeclaration.java
@@ -19,6 +19,7 @@ import wyvern.tools.typedAST.core.binding.NameBinding;
 import wyvern.tools.typedAST.core.binding.NameBindingImpl;
 import wyvern.tools.typedAST.core.binding.evaluation.VarValueBinding;
 import wyvern.tools.typedAST.core.binding.typechecking.AssignableNameBinding;
+import wyvern.tools.typedAST.core.expressions.Assignment;
 import wyvern.tools.typedAST.core.expressions.Invocation;
 import wyvern.tools.typedAST.core.expressions.New;
 import wyvern.tools.typedAST.interfaces.CoreAST;
@@ -204,12 +205,26 @@ public class VarDeclaration extends Declaration implements CoreAST {
 
 		// Create a declaration for the anonymous object's getter.
 		String getterName = TopLevelContext.anonymousGetterName();
-		wyvern.tools.typedAST.core.expressions.Variable selfReference = new
+		wyvern.tools.typedAST.core.expressions.Variable selfReferenceGetter = new
 				wyvern.tools.typedAST.core.expressions.Variable(new NameBindingImpl("this", null), null);
-		Invocation getterBody = new Invocation(selfReference, varName, null, null);
+		Invocation getterBody = new Invocation(selfReferenceGetter, varName, null, null);
 		DefDeclaration getterDecl = new DefDeclaration(getterName, typeOfVar, new LinkedList<>(),
 														 getterBody, false, null);
 		decls.add(getterDecl);
+		
+		// Create a declaration for the anonymous object's setter.
+		String setterName = TopLevelContext.anonymousSetterName();
+		wyvern.tools.typedAST.core.expressions.Variable selfReferenceSetter = new
+				wyvern.tools.typedAST.core.expressions.Variable(new NameBindingImpl("this", null), null);
+		Invocation fieldGet = new Invocation(selfReferenceSetter, varName, null, null);
+		wyvern.tools.typedAST.core.expressions.Variable valueToAssign =
+				new wyvern.tools.typedAST.core.expressions.Variable(new NameBindingImpl("x", null), null);
+		Assignment setterBody = new Assignment(fieldGet, valueToAssign, null);
+		LinkedList<NameBinding> formalArguments = new LinkedList<>();
+		formalArguments.add(new NameBindingImpl("x", typeOfVar));
+		DefDeclaration setterDecl = new DefDeclaration(setterName, typeOfVar, formalArguments,
+														setterBody, false, null);
+		decls.add(setterDecl);
 		
 		// Create the anonymous object.
 		DeclSequence declSeq = new DeclSequence(decls);

--- a/tools/src/wyvern/tools/typedAST/core/expressions/Assignment.java
+++ b/tools/src/wyvern/tools/typedAST/core/expressions/Assignment.java
@@ -4,6 +4,7 @@ import wyvern.target.corewyvernIL.expression.*;
 import wyvern.target.corewyvernIL.expression.Variable;
 import wyvern.target.corewyvernIL.support.CallableExprGenerator;
 import wyvern.target.corewyvernIL.support.GenContext;
+import wyvern.target.corewyvernIL.support.TopLevelContext;
 import wyvern.target.corewyvernIL.type.ValueType;
 import wyvern.tools.errors.ErrorMessage;
 import wyvern.tools.errors.FileLocation;
@@ -146,4 +147,32 @@ public class Assignment extends CachingTypedAST implements CoreAST {
 		return new wyvern.target.corewyvernIL.expression.FieldSet(exprType, objExpr, fieldName, exprToAssign);
 	
 	}
+	
+	@Override
+	public void genTopLevel (TopLevelContext tlc) {
+		
+		// Figure out receiver and field. At the moment this is not ideal: it will only support top-level assignations
+		// of the form x = ___, where x is a variable. If x is a compound expression that evaluates to a variable, this
+		// will not work. We should get a callable experssion instead, but since top-level vars aren't stored in the
+		// context with their actual name, this doesn't work at the moment.
+		if (!(target instanceof wyvern.tools.typedAST.core.expressions.Variable)) {
+			super.genTopLevel(tlc);
+			return;
+		}
+		
+		// Otherwise turn this var write into a method call to the anon object's setter.
+		wyvern.tools.typedAST.core.expressions. Variable varWrite = (wyvern.tools.typedAST.core.expressions.Variable) target;
+		String varName = varWrite.getName();
+		Optional<wyvern.tools.typedAST.core.expressions.Variable> anonReferenceOpt = tlc.anonymousObjectReference(varName);
+		if (!anonReferenceOpt.isPresent())
+			ToolError.reportError(ErrorMessage.VARIABLE_NOT_DECLARED, this, varName);
+		wyvern.tools.typedAST.core.expressions.Variable anonReference = anonReferenceOpt.get();
+		
+		// Create a method call to the anon object's setter.
+		Invocation anonInvocation = new Invocation(anonReference, TopLevelContext.anonymousSetterName(), null, null);
+		Application anonMethodCall = new Application(anonInvocation, this.value, null);
+		anonMethodCall.genTopLevel(tlc);
+		
+	}
+	
 }

--- a/tools/src/wyvern/tools/typedAST/core/expressions/Assignment.java
+++ b/tools/src/wyvern/tools/typedAST/core/expressions/Assignment.java
@@ -134,7 +134,7 @@ public class Assignment extends CachingTypedAST implements CoreAST {
 		// Figure out receiver and field.
 		CallableExprGenerator cegReceiver = target.getCallableExpr(ctx);
 		Expression exprFieldGet = cegReceiver.genExpr();
-		if (!(target instanceof FieldGet))
+		if (!(exprFieldGet instanceof FieldGet))
 			ToolError.reportError(ErrorMessage.NOT_ASSIGNABLE, this);
 		
 		// Extract information from FieldGet.

--- a/tools/src/wyvern/tools/typedAST/core/expressions/Assignment.java
+++ b/tools/src/wyvern/tools/typedAST/core/expressions/Assignment.java
@@ -7,7 +7,6 @@ import wyvern.target.corewyvernIL.support.GenContext;
 import wyvern.target.corewyvernIL.type.ValueType;
 import wyvern.tools.errors.ErrorMessage;
 import wyvern.tools.errors.FileLocation;
-import wyvern.tools.errors.HasLocation;
 import wyvern.tools.errors.ToolError;
 import wyvern.tools.typedAST.abs.CachingTypedAST;
 import wyvern.tools.typedAST.interfaces.*;
@@ -135,8 +134,10 @@ public class Assignment extends CachingTypedAST implements CoreAST {
 		// Figure out receiver and field.
 		CallableExprGenerator cegReceiver = target.getCallableExpr(ctx);
 		Expression exprFieldGet = cegReceiver.genExpr();
-		if (!(exprFieldGet instanceof FieldGet))
+		if (!(target instanceof wyvern.tools.typedAST.core.expressions.Variable))
 			ToolError.reportError(ErrorMessage.NOT_ASSIGNABLE, this);
+		
+		// Extract information from FieldGet.
 		FieldGet fieldGet = (FieldGet) exprFieldGet;
 		String fieldName = fieldGet.getName();
 		IExpr objExpr = fieldGet.getObjectExpr();

--- a/tools/src/wyvern/tools/typedAST/core/expressions/Assignment.java
+++ b/tools/src/wyvern/tools/typedAST/core/expressions/Assignment.java
@@ -134,7 +134,7 @@ public class Assignment extends CachingTypedAST implements CoreAST {
 		// Figure out receiver and field.
 		CallableExprGenerator cegReceiver = target.getCallableExpr(ctx);
 		Expression exprFieldGet = cegReceiver.genExpr();
-		if (!(target instanceof wyvern.tools.typedAST.core.expressions.Variable))
+		if (!(target instanceof FieldGet))
 			ToolError.reportError(ErrorMessage.NOT_ASSIGNABLE, this);
 		
 		// Extract information from FieldGet.

--- a/tools/src/wyvern/tools/typedAST/core/expressions/Variable.java
+++ b/tools/src/wyvern/tools/typedAST/core/expressions/Variable.java
@@ -141,10 +141,15 @@ public class Variable extends AbstractExpressionAST implements CoreAST, Assignab
 	@Override
 	public void genTopLevel (TopLevelContext tlc) {
 		
-		// TODO: only perform the below if the variable in question was declared with Var.
-		// Otherwise, perform the default genTopLevel.
+		// If the variable is defined in the context, it was declared with val.
+		// Do the default top level generation (as defined by ExpressionAST).
+		GenContext ctx = tlc.getContext();
+		if (ctx.isDefined(this.getName())) {
+			super.genTopLevel(tlc);
+			return;
+		}
 		
-		// Figure out name of anonymous object.
+		// Otherwise it was declared with var. Figure out name of anonymous object.
 		Optional<Variable> anonReferenceOpt = tlc.anonymousObjectReference(this.getName());
 		if (!anonReferenceOpt.isPresent())
 			ToolError.reportError(ErrorMessage.VARIABLE_NOT_DECLARED, this, this.getName());

--- a/tools/src/wyvern/tools/typedAST/core/expressions/Variable.java
+++ b/tools/src/wyvern/tools/typedAST/core/expressions/Variable.java
@@ -141,6 +141,9 @@ public class Variable extends AbstractExpressionAST implements CoreAST, Assignab
 	@Override
 	public void genTopLevel (TopLevelContext tlc) {
 		
+		// TODO: only perform the below if the variable in question was declared with Var.
+		// Otherwise, perform the default genTopLevel.
+		
 		// Figure out name of anonymous object.
 		Optional<Variable> anonReferenceOpt = tlc.anonymousObjectReference(this.getName());
 		if (!anonReferenceOpt.isPresent())

--- a/tools/src/wyvern/tools/typedAST/core/expressions/Variable.java
+++ b/tools/src/wyvern/tools/typedAST/core/expressions/Variable.java
@@ -147,7 +147,7 @@ public class Variable extends AbstractExpressionAST implements CoreAST, Assignab
 		// Figure out name of anonymous object.
 		Optional<Variable> anonReferenceOpt = tlc.anonymousObjectReference(this.getName());
 		if (!anonReferenceOpt.isPresent())
-			ToolError.reportError(ErrorMessage.VARIABLE_NOT_DECLARED, this);
+			ToolError.reportError(ErrorMessage.VARIABLE_NOT_DECLARED, this, this.getName());
 		Variable anonReference = anonReferenceOpt.get();
 		
 		// Replace with an invocation to anonymous object's getter method.

--- a/tools/src/wyvern/tools/typedAST/core/expressions/Variable.java
+++ b/tools/src/wyvern/tools/typedAST/core/expressions/Variable.java
@@ -10,12 +10,16 @@ import wyvern.target.corewyvernIL.expression.FieldGet;
 import wyvern.target.corewyvernIL.expression.MethodCall;
 import wyvern.target.corewyvernIL.support.CallableExprGenerator;
 import wyvern.target.corewyvernIL.support.GenContext;
+import wyvern.target.corewyvernIL.support.TopLevelContext;
 import wyvern.target.corewyvernIL.support.TypeContext;
 import wyvern.target.corewyvernIL.type.ValueType;
+import wyvern.tools.errors.ErrorMessage;
 import wyvern.tools.errors.FileLocation;
+import wyvern.tools.errors.ToolError;
 import wyvern.tools.typedAST.abs.AbstractExpressionAST;
 import wyvern.tools.typedAST.core.binding.AssignableValueBinding;
 import wyvern.tools.typedAST.core.binding.NameBinding;
+import wyvern.tools.typedAST.core.binding.NameBindingImpl;
 import wyvern.tools.typedAST.core.binding.typechecking.AssignableNameBinding;
 import wyvern.tools.typedAST.core.values.VarValue;
 import wyvern.tools.typedAST.interfaces.*;
@@ -143,4 +147,20 @@ public class Variable extends AbstractExpressionAST implements CoreAST, Assignab
 	public CallableExprGenerator getCallableExpr(GenContext ctx) {
 		return ctx.getCallableExpr(getName());
 	}
+	
+	@Override
+	public void genTopLevel (TopLevelContext tlc) {
+		
+		// Figure out name of anonymous object.
+		Optional<Variable> anonReferenceOpt = tlc.anonymousObjectReference(this.getName());
+		if (!anonReferenceOpt.isPresent())
+			ToolError.reportError(ErrorMessage.VARIABLE_NOT_DECLARED, this);
+		Variable anonReference = anonReferenceOpt.get();
+		
+		// Replace with an invocation to anonymous object's getter.
+		Invocation inv = new Invocation(anonReference, TopLevelContext.anonymousGetterName(), null, null);
+		inv.genTopLevel(tlc);
+		
+	}
+	
 }

--- a/tools/src/wyvern/tools/typedAST/core/expressions/Variable.java
+++ b/tools/src/wyvern/tools/typedAST/core/expressions/Variable.java
@@ -1,26 +1,17 @@
 package wyvern.tools.typedAST.core.expressions;
 
-import wyvern.target.corewyvernIL.FormalArg;
-import wyvern.target.corewyvernIL.decltype.DeclType;
-import wyvern.target.corewyvernIL.decltype.DefDeclType;
-import wyvern.target.corewyvernIL.decltype.ValDeclType;
-import wyvern.target.corewyvernIL.decltype.VarDeclType;
 import wyvern.target.corewyvernIL.expression.Expression;
-import wyvern.target.corewyvernIL.expression.FieldGet;
-import wyvern.target.corewyvernIL.expression.MethodCall;
 import wyvern.target.corewyvernIL.support.CallableExprGenerator;
 import wyvern.target.corewyvernIL.support.GenContext;
 import wyvern.target.corewyvernIL.support.TopLevelContext;
-import wyvern.target.corewyvernIL.support.TypeContext;
-import wyvern.target.corewyvernIL.type.ValueType;
 import wyvern.tools.errors.ErrorMessage;
 import wyvern.tools.errors.FileLocation;
 import wyvern.tools.errors.ToolError;
 import wyvern.tools.typedAST.abs.AbstractExpressionAST;
 import wyvern.tools.typedAST.core.binding.AssignableValueBinding;
 import wyvern.tools.typedAST.core.binding.NameBinding;
-import wyvern.tools.typedAST.core.binding.NameBindingImpl;
 import wyvern.tools.typedAST.core.binding.typechecking.AssignableNameBinding;
+import wyvern.tools.typedAST.core.values.UnitVal;
 import wyvern.tools.typedAST.core.values.VarValue;
 import wyvern.tools.typedAST.interfaces.*;
 import wyvern.tools.typedAST.transformers.GenerationEnvironment;
@@ -33,7 +24,6 @@ import wyvern.tools.util.EvaluationEnvironment;
 import wyvern.tools.util.TreeWriter;
 
 import java.util.Hashtable;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -157,9 +147,10 @@ public class Variable extends AbstractExpressionAST implements CoreAST, Assignab
 			ToolError.reportError(ErrorMessage.VARIABLE_NOT_DECLARED, this);
 		Variable anonReference = anonReferenceOpt.get();
 		
-		// Replace with an invocation to anonymous object's getter.
-		Invocation inv = new Invocation(anonReference, TopLevelContext.anonymousGetterName(), null, null);
-		inv.genTopLevel(tlc);
+		// Replace with an invocation to anonymous object's getter method.
+		Invocation anonInvocation = new Invocation(anonReference, TopLevelContext.anonymousGetterName(), null, null);
+		Application anonMethodCall = new Application(anonInvocation, UnitVal.getInstance(null), null);
+		anonMethodCall.genTopLevel(tlc);
 		
 	}
 	

--- a/tools/src/wyvern/tools/types/extensions/Int.java
+++ b/tools/src/wyvern/tools/types/extensions/Int.java
@@ -100,7 +100,6 @@ public class Int extends AbstractTypeImpl implements OperatableType {
 
 	@Override
 	public ValueType getILType(GenContext ctx) {
-		// TODO Auto-generated method stub
-		return null;
+		return wyvern.target.corewyvernIL.support.Util.intType();
 	}
 }


### PR DESCRIPTION
This PR adds a few tests in ModuleSystemTests to demonstrate declaration of var fields in modules as well as reading and writing.

When a var is declared at the top-level it generates a new object with a single field and methods for getting and setting that field. These are called "anonymous objects" throughout the code. TopLevelContext maintains a mapping from variable names to the names of their anonymous objects. There are a few methods in TopLevelContext for handling that (they're called anonymousObjectName, anonymousObjectReference, and anonymousObjectGenerate).

When a Var read or write is encountered during top level IL generation, it is turned into an appropriate method invocation of the anonymous object.

Here's an example of some of the code generated.

```
var v : Int = 5
v = 10
v
```

Becomes:

```
let
    _temp_v = new this : type { this =>
        var v : system.Int
        def get() : system.Int
        def set(x:system.Int) : system.Int
      } =>
        var v:system.Int = 5
        def get() : system.Int
            this.v
        def set(x:system.Int) : system.Int
            this.v = x

in let
    var_0 = _temp_v.set(10)

in _temp_v.get()
```

In this example, the var declaration for v gets turned into the anonymous object _temp_v, which has methods get and set.