### PR TITLE
Adding in an arrow sugar for function types

### DIFF
--- a/tools/src/wyvern/tools/parsing/coreparser/ASTBuilder.java
+++ b/tools/src/wyvern/tools/parsing/coreparser/ASTBuilder.java
@@ -39,7 +39,7 @@ public interface ASTBuilder<AST,Type> {
 	public Object tagInfo(Type type, List<Type> comprises);
 	
 	public Type nominalType(String name, FileLocation loc);
-	
+	public Type arrowType(Type argument, Type result);
 	
 	public Type qualifiedType(AST base, String name);
 	

--- a/tools/src/wyvern/tools/parsing/coreparser/WyvernASTBuilder.java
+++ b/tools/src/wyvern/tools/parsing/coreparser/WyvernASTBuilder.java
@@ -39,6 +39,7 @@ import wyvern.tools.typedAST.interfaces.TypedAST;
 import wyvern.tools.typedAST.interfaces.Value;
 import wyvern.tools.types.QualifiedType;
 import wyvern.tools.types.Type;
+import wyvern.tools.types.extensions.Arrow;
 import wyvern.tools.types.UnresolvedType;
 import wyvern.tools.util.Reference;
 
@@ -124,6 +125,11 @@ public class WyvernASTBuilder implements ASTBuilder<TypedAST, Type> {
 		return new UnresolvedType(name, loc);
 	}
 	
+    @Override
+	public Type arrowType(Type argument, Type result) {
+		return new Arrow(argument, result);
+	}
+
 	@Override
 	public Type qualifiedType(TypedAST base, String name) {
 		return new QualifiedType(base, name);

--- a/tools/src/wyvern/tools/parsing/coreparser/WyvernParser.jj
+++ b/tools/src/wyvern/tools/parsing/coreparser/WyvernParser.jj
@@ -460,24 +460,18 @@ Type Type() :
 	}
   	id = id2;
  })* (<TARROW> arrowResult = Type() )? {
-    if (arrowResult == null) {
-        if(exp == null) {
-		    return build.nominalType(id.image, loc(id));
-        } else {
-  		    return build.qualifiedType(exp, id2.image);
-        }
+
+    Type t;
+    if (exp == null) {
+        t = build.nominalType(id.image, loc(id));
     } else {
-        if(exp == null) {
-            return build.arrowType(
-                build.nominalType(id.image, loc(id)),
-                arrowResult
-            );
-        } else {
-            return build.arrowType(
-                build.nominalType(id.image, loc(id)),
-                arrowResult
-            );
-        }
+        t = build.qualifiedType(exp, id2.image);
+    }
+
+    if (arrowResult == null) {
+        return t;
+    } else {
+        return build.arrowType(t, arrowResult);
     }
  }
 }

--- a/tools/src/wyvern/tools/parsing/coreparser/WyvernParser.jj
+++ b/tools/src/wyvern/tools/parsing/coreparser/WyvernParser.jj
@@ -450,7 +450,7 @@ List<Type> TypeList() :
 }
 
 Type Type() :
-{ Token id = null; Token id2 = null; AST exp = null; }
+{ Token id = null; Token id2 = null; AST exp = null; Type arrowResult = null; }
 {
   id = <IDENTIFIER> (<DOT> id2 = <IDENTIFIER> {
 	if (exp == null) {
@@ -459,12 +459,27 @@ Type Type() :
 		exp = build.invocation(exp, id.image, null, loc(id));
 	}
   	id = id2;
-  })* {
-	if (exp == null)
-		return build.nominalType(id.image, loc(id));
-  	else
-  		return build.qualifiedType(exp, id2.image);
-  }
+ })* (<TARROW> arrowResult = Type() )? {
+    if (arrowResult == null) {
+        if(exp == null) {
+		    return build.nominalType(id.image, loc(id));
+        } else {
+  		    return build.qualifiedType(exp, id2.image);
+        }
+    } else {
+        if(exp == null) {
+            return build.arrowType(
+                build.nominalType(id.image, loc(id)),
+                arrowResult
+            );
+        } else {
+            return build.arrowType(
+                build.nominalType(id.image, loc(id)),
+                arrowResult
+            );
+        }
+    }
+ }
 }
 
 AST AdditiveExpression(ExpFlags flags) :

--- a/tools/src/wyvern/tools/tests/ILTests.java
+++ b/tools/src/wyvern/tools/tests/ILTests.java
@@ -578,6 +578,9 @@ public class ILTests {
     }
 
     @Test
+    /**
+     * Checks to see if the .apply() sugar on lambda fns recognizes
+     */
     public void testSimpleLambda2() throws ParseException {
 
         String source = "type UnitIntFn \n"
@@ -821,4 +824,25 @@ public class ILTests {
 		} catch (ToolError toolError) {}
 	}
 	
+
+    @Test
+    public void testArrowSugar() throws ParseException {
+
+        String source = "val identity: system.Int->system.Int = (x: system.Int) => x\n"
+            + "identity(10)";
+
+        ExpressionAST ast = (ExpressionAST) TestUtil.getNewAST(source);
+
+        GenContext genCtx = GenContext.empty().extend("system", new Variable("system"), null);
+        Expression program = ast.generateIL(genCtx, null);
+        TypeContext ctx = TypeContext.empty();
+
+        ValueType t = program.typeCheck(ctx);
+
+        Assert.assertEquals(Util.intType(), t);
+
+        Value v = program.interpret(EvalContext.empty());
+        IntegerLiteral five = new IntegerLiteral(10);
+        Assert.assertEquals(five, v);
+    }
 }


### PR DESCRIPTION
This guy adds a sugar for representing parameter and return types.
For example, `val identity: system.Int->system.Int = (x: system.Int) => x\n` creates a lambda function that returns it's argument. Note the Haskell-esque arrow sugar on the left hand side of the assignment. That's the sugar added by this commit.