### PR TITLE
Free Variables

### DIFF
--- a/tools/src/wyvern/target/corewyvernIL/decl/Declaration.java
+++ b/tools/src/wyvern/target/corewyvernIL/decl/Declaration.java
@@ -1,5 +1,7 @@
 package wyvern.target.corewyvernIL.decl;
 
+import java.util.Set;
+
 import wyvern.target.corewyvernIL.ASTNode;
 import wyvern.target.corewyvernIL.EmitOIR;
 import wyvern.target.corewyvernIL.decltype.DeclType;
@@ -19,4 +21,7 @@ public abstract class Declaration extends ASTNode implements EmitOIR {
 
 	/** Returns the name of this declaration, or null if this declaration is not named */
 	public abstract String getName();
+
+	public abstract Set<String> getFreeVariables();
+
 }

--- a/tools/src/wyvern/target/corewyvernIL/decl/DefDeclaration.java
+++ b/tools/src/wyvern/target/corewyvernIL/decl/DefDeclaration.java
@@ -84,13 +84,16 @@ public class DefDeclaration extends NamedDeclaration {
 
 	@Override
 	public Set<String> getFreeVariables() {
-		Set<String> boundVars = new HashSet<>();
-		boundVars.add(this.getName());
-		for (FormalArg farg : formalArgs) {
-			boundVars.add(farg.getName());
-		}
+		
+		// Get all free variables in the body of the method.
 		Set<String> freeVars = body.getFreeVariables();
-		freeVars.removeAll(boundVars);
+		
+		// Remove variables that became bound in this method's scope.
+		freeVars.remove(this.getName());
+		for (FormalArg farg : formalArgs) {
+			freeVars.remove(farg.getName());
+		}
+		
 		return freeVars;
 	}
 

--- a/tools/src/wyvern/target/corewyvernIL/decl/DefDeclaration.java
+++ b/tools/src/wyvern/target/corewyvernIL/decl/DefDeclaration.java
@@ -1,7 +1,6 @@
 package wyvern.target.corewyvernIL.decl;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 

--- a/tools/src/wyvern/target/corewyvernIL/decl/DefDeclaration.java
+++ b/tools/src/wyvern/target/corewyvernIL/decl/DefDeclaration.java
@@ -88,11 +88,9 @@ public class DefDeclaration extends NamedDeclaration {
 		Set<String> freeVars = body.getFreeVariables();
 		
 		// Remove variables that became bound in this method's scope.
-		freeVars.remove(this.getName());
 		for (FormalArg farg : formalArgs) {
 			freeVars.remove(farg.getName());
 		}
-		
 		return freeVars;
 	}
 

--- a/tools/src/wyvern/target/corewyvernIL/decl/DefDeclaration.java
+++ b/tools/src/wyvern/target/corewyvernIL/decl/DefDeclaration.java
@@ -1,7 +1,9 @@
 package wyvern.target.corewyvernIL.decl;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import wyvern.target.corewyvernIL.Environment;
 import wyvern.target.corewyvernIL.FormalArg;
@@ -18,7 +20,7 @@ public class DefDeclaration extends NamedDeclaration {
 	private List<FormalArg> formalArgs;
 	private ValueType type;
 	private Expression body;
-	
+
 	public DefDeclaration(String methodName, List<FormalArg> formalArgs,
 			ValueType type, Expression body) {
 		super(methodName);
@@ -51,15 +53,15 @@ public class DefDeclaration extends NamedDeclaration {
 	public String toString() {
 		return "DefDeclaration[" + getName() + "(...) : " + type + " = " + body + "]";
 	}*/
-	
+
 	public List<FormalArg> getFormalArgs() {
 		return formalArgs;
 	}
-	
+
 	public ValueType getType() {
 		return type;
 	}
-	
+
 	public Expression getBody() {
 		return body;
 	}
@@ -79,4 +81,17 @@ public class DefDeclaration extends NamedDeclaration {
 			throw new RuntimeException("body doesn't match declared type");
 		return new DefDeclType(getName(), type, formalArgs);
 	}
+
+	@Override
+	public Set<String> getFreeVariables() {
+		Set<String> boundVars = new HashSet<>();
+		boundVars.add(this.getName());
+		for (FormalArg farg : formalArgs) {
+			boundVars.add(farg.getName());
+		}
+		Set<String> freeVars = body.getFreeVariables();
+		freeVars.removeAll(boundVars);
+		return freeVars;
+	}
+
 }

--- a/tools/src/wyvern/target/corewyvernIL/decl/DelegateDeclaration.java
+++ b/tools/src/wyvern/target/corewyvernIL/decl/DelegateDeclaration.java
@@ -10,7 +10,7 @@ import wyvern.target.corewyvernIL.support.TypeContext;
 import wyvern.target.corewyvernIL.type.ValueType;
 import wyvern.target.oir.OIREnvironment;
 
-public class DelegateDeclaration extends Declaration{
+public class DelegateDeclaration extends Declaration {
 
 	private ValueType valueType;
 	private String fieldName;
@@ -48,8 +48,6 @@ public class DelegateDeclaration extends Declaration{
 
 	@Override
 	public Set<String> getFreeVariables() {
-		Set<String> freeVars = new HashSet<>();
-		freeVars.add(fieldName);
-		return freeVars;
+		return new HashSet<>();
 	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/decl/DelegateDeclaration.java
+++ b/tools/src/wyvern/target/corewyvernIL/decl/DelegateDeclaration.java
@@ -1,5 +1,8 @@
 package wyvern.target.corewyvernIL.decl;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import wyvern.target.corewyvernIL.Environment;
 import wyvern.target.corewyvernIL.astvisitor.ASTVisitor;
 import wyvern.target.corewyvernIL.decltype.DeclType;
@@ -11,7 +14,7 @@ public class DelegateDeclaration extends Declaration{
 
 	private ValueType valueType;
 	private String fieldName;
-	
+
 	public DelegateDeclaration(ValueType valueType, String fieldName) {
 		super();
 		this.valueType = valueType;
@@ -21,11 +24,11 @@ public class DelegateDeclaration extends Declaration{
 	public ValueType getValueType() {
 		return valueType;
 	}
-	
+
 	public String getFieldName() {
 		return fieldName;
 	}
-	
+
 	@Override
 	public <T> T acceptVisitor(ASTVisitor <T> emitILVisitor,
 			Environment env, OIREnvironment oirenv) {
@@ -41,5 +44,12 @@ public class DelegateDeclaration extends Declaration{
 	@Override
 	public String getName() {
 		return null;
+	}
+
+	@Override
+	public Set<String> getFreeVariables() {
+		Set<String> freeVars = new HashSet<>();
+		freeVars.add(fieldName);
+		return freeVars;
 	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/decl/TypeDeclaration.java
+++ b/tools/src/wyvern/target/corewyvernIL/decl/TypeDeclaration.java
@@ -1,6 +1,8 @@
 package wyvern.target.corewyvernIL.decl;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 import wyvern.target.corewyvernIL.Environment;
 import wyvern.target.corewyvernIL.astvisitor.ASTVisitor;
@@ -19,7 +21,7 @@ public class TypeDeclaration extends NamedDeclaration {
 	}
 
 	private Type sourceType;
-	
+
 	public Type getSourceType() {
 		return sourceType;
 	}
@@ -33,10 +35,10 @@ public class TypeDeclaration extends NamedDeclaration {
 
 	@Override
 	public DeclType typeCheck(TypeContext ctx, TypeContext thisCtx) {
-		DeclType declt = new ConcreteTypeMember(super.getName(), (ValueType) this.sourceType); 
+		DeclType declt = new ConcreteTypeMember(super.getName(), (ValueType) this.sourceType);
 		return declt;
 	}
-	
+
 	@Override
 	public void doPrettyPrint(Appendable dest, String indent) throws IOException {
 		dest.append(indent).append("type ").append(getName()).append(" = ");
@@ -48,4 +50,9 @@ public class TypeDeclaration extends NamedDeclaration {
 	public String toString() {
 		return "type declaration " + super.getName() + " = " + sourceType.toString();
 	}*/
+
+	@Override
+	public Set<String> getFreeVariables() {
+		return new HashSet<>();
+	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/decl/ValDeclaration.java
+++ b/tools/src/wyvern/target/corewyvernIL/decl/ValDeclaration.java
@@ -1,6 +1,8 @@
 package wyvern.target.corewyvernIL.decl;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 import wyvern.target.corewyvernIL.Environment;
 import wyvern.target.corewyvernIL.astvisitor.ASTVisitor;
@@ -24,12 +26,12 @@ public class ValDeclaration extends DeclarationWithRHS {
 	}
 
 	private ValueType type;
-	
+
 	@Override
 	public ValueType getType() {
 		return type;
 	}
-	
+
 	@Override
 	public void doPrettyPrint(Appendable dest, String indent) throws IOException {
 		dest.append(indent).append("val ").append(getName()).append(':');
@@ -49,11 +51,17 @@ public class ValDeclaration extends DeclarationWithRHS {
 	public DeclType getDeclType() {
 		return new ValDeclType(getName(), type);
 	}
-	
+
 	@Override
 	public Declaration interpret(EvalContext ctx) {
 		Expression newValue = (Expression) getDefinition().interpret(ctx);
 		return new ValDeclaration(getName(), type, newValue);
+	}
+
+	public Set<String> getFreeVariables() {
+		Set<String> freeVars = new HashSet<>();
+		freeVars.add(this.getName());
+		return freeVars;
 	}
 
 }

--- a/tools/src/wyvern/target/corewyvernIL/decl/ValDeclaration.java
+++ b/tools/src/wyvern/target/corewyvernIL/decl/ValDeclaration.java
@@ -60,7 +60,7 @@ public class ValDeclaration extends DeclarationWithRHS {
 
 	public Set<String> getFreeVariables() {
 		Set<String> freeVars = new HashSet<>();
-		freeVars.add(this.getName());
+		freeVars.addAll(getDefinition().getFreeVariables());
 		return freeVars;
 	}
 

--- a/tools/src/wyvern/target/corewyvernIL/decl/ValDeclaration.java
+++ b/tools/src/wyvern/target/corewyvernIL/decl/ValDeclaration.java
@@ -59,9 +59,7 @@ public class ValDeclaration extends DeclarationWithRHS {
 	}
 
 	public Set<String> getFreeVariables() {
-		Set<String> freeVars = new HashSet<>();
-		freeVars.addAll(getDefinition().getFreeVariables());
-		return freeVars;
+		return getDefinition().getFreeVariables();
 	}
 
 }

--- a/tools/src/wyvern/target/corewyvernIL/decl/VarDeclaration.java
+++ b/tools/src/wyvern/target/corewyvernIL/decl/VarDeclaration.java
@@ -61,7 +61,7 @@ public class VarDeclaration extends DeclarationWithRHS {
 
 	public Set<String> getFreeVariables() {
 		Set<String> freeVars = new HashSet<>();
-		freeVars.add(this.getName());
+		freeVars.addAll(getDefinition().getFreeVariables());
 		return freeVars;
 	}
 

--- a/tools/src/wyvern/target/corewyvernIL/decl/VarDeclaration.java
+++ b/tools/src/wyvern/target/corewyvernIL/decl/VarDeclaration.java
@@ -1,6 +1,8 @@
 package wyvern.target.corewyvernIL.decl;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 import wyvern.target.corewyvernIL.Environment;
 import wyvern.target.corewyvernIL.astvisitor.ASTVisitor;
@@ -14,7 +16,7 @@ import wyvern.target.oir.OIREnvironment;
 public class VarDeclaration extends DeclarationWithRHS {
 
 	private ValueType type;
-	
+
 	/*@Override
 	public String toString() {
 		return "VarDeclaration[" + getName() + " : " + type + " = " + getDefinition() + "]";
@@ -25,7 +27,7 @@ public class VarDeclaration extends DeclarationWithRHS {
 		if (type == null) throw new RuntimeException();
 		this.type = type;
 	}
-	
+
 	@Override
 	public void doPrettyPrint(Appendable dest, String indent) throws IOException {
 		dest.append(indent).append("var ").append(getName()).append(':');
@@ -39,7 +41,7 @@ public class VarDeclaration extends DeclarationWithRHS {
 	public ValueType getType() {
 		return type;
 	}
-	
+
 	@Override
 	public <T> T acceptVisitor(ASTVisitor <T> emitILVisitor,
 			Environment env, OIREnvironment oirenv) {
@@ -50,11 +52,17 @@ public class VarDeclaration extends DeclarationWithRHS {
 	public DeclType getDeclType() {
 		return new VarDeclType(getName(), type);
 	}
-	
+
 	@Override
 	public Declaration interpret(EvalContext ctx) {
 		Expression newValue = (Expression) getDefinition().interpret(ctx);
 		return new VarDeclaration(getName(), type, newValue);
+	}
+
+	public Set<String> getFreeVariables() {
+		Set<String> freeVars = new HashSet<>();
+		freeVars.add(this.getName());
+		return freeVars;
 	}
 
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/AbstractValue.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/AbstractValue.java
@@ -1,5 +1,8 @@
 package wyvern.target.corewyvernIL.expression;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import wyvern.target.corewyvernIL.support.EvalContext;
 import wyvern.target.corewyvernIL.type.ValueType;
 
@@ -13,4 +16,5 @@ public abstract class AbstractValue extends Expression implements Value {
 	public Value interpret(EvalContext ctx) {
 		return this;
 	}
+	
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/AbstractValue.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/AbstractValue.java
@@ -1,8 +1,5 @@
 package wyvern.target.corewyvernIL.expression;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import wyvern.target.corewyvernIL.support.EvalContext;
 import wyvern.target.corewyvernIL.type.ValueType;
 

--- a/tools/src/wyvern/target/corewyvernIL/expression/Bind.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/Bind.java
@@ -1,6 +1,7 @@
 package wyvern.target.corewyvernIL.expression;
 
 import java.io.IOException;
+import java.util.Set;
 
 import wyvern.target.corewyvernIL.Environment;
 import wyvern.target.corewyvernIL.astvisitor.ASTVisitor;
@@ -12,6 +13,10 @@ import wyvern.target.oir.OIREnvironment;
 
 public class Bind extends Expression {
 
+	private String varName;
+	private Expression toReplace;
+	private Expression inExpr;
+
 	@Override
 	public void doPrettyPrint(Appendable dest, String indent) throws IOException {
 		String newIndent = indent + "    ";
@@ -22,10 +27,6 @@ public class Bind extends Expression {
 		inExpr.doPrettyPrint(dest,indent);
 	}
 
-	private String varName;
-	private Expression toReplace;
-	private Expression inExpr;
-	
 	public Bind(String varName, Expression toReplace, Expression inExpr) {
 		super();
 		this.varName = varName;
@@ -38,15 +39,15 @@ public class Bind extends Expression {
 	public String getVarName() {
 		return varName;
 	}
-	
+
 	public Expression getToReplace() {
 		return toReplace;
 	}
-	
+
 	public Expression getInExpr() {
 		return inExpr;
 	}
-	
+
 	@Override
 	public ValueType typeCheck(TypeContext ctx) {
 		ValueType t = toReplace.typeCheck(ctx);
@@ -65,5 +66,13 @@ public class Bind extends Expression {
 		// TODO: not sure this implementation is quite right
 		Value v = toReplace.interpret(ctx);
 		return inExpr.interpret(ctx.extend(varName, v));
+	}
+
+	@Override
+	public Set<String> getFreeVariables() {
+		Set<String> freeVars = toReplace.getFreeVariables();
+		freeVars.addAll(inExpr.getFreeVariables());
+		freeVars.remove(varName);
+		return freeVars;
 	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/Bind.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/Bind.java
@@ -70,8 +70,12 @@ public class Bind extends Expression {
 
 	@Override
 	public Set<String> getFreeVariables() {
+		
+		// Get free variables in the sub-expressions.
 		Set<String> freeVars = toReplace.getFreeVariables();
 		freeVars.addAll(inExpr.getFreeVariables());
+		
+		// Remove the name that just became bound.
 		freeVars.remove(varName);
 		return freeVars;
 	}

--- a/tools/src/wyvern/target/corewyvernIL/expression/Bind.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/Bind.java
@@ -70,13 +70,6 @@ public class Bind extends Expression {
 
 	@Override
 	public Set<String> getFreeVariables() {
-		
-		// Get free variables in the sub-expressions.
-		Set<String> freeVars = toReplace.getFreeVariables();
-		freeVars.addAll(inExpr.getFreeVariables());
-		
-		// Remove the name that just became bound.
-		freeVars.remove(varName);
-		return freeVars;
+		return toReplace.getFreeVariables();
 	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/BooleanLiteral.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/BooleanLiteral.java
@@ -1,6 +1,8 @@
 package wyvern.target.corewyvernIL.expression;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 import wyvern.target.corewyvernIL.Environment;
 import wyvern.target.corewyvernIL.astvisitor.ASTVisitor;
@@ -25,7 +27,7 @@ public class BooleanLiteral extends AbstractValue {
 	public void doPrettyPrint(Appendable dest, String indent) throws IOException {
 		dest.append(value?"true":"false");
 	}
-	
+
     @Override
     public ValueType typeCheck(TypeContext env) {
         // TODO Auto-generated method stub
@@ -38,5 +40,11 @@ public class BooleanLiteral extends AbstractValue {
 		// TODO Auto-generated method stub
 		return null;
 	}
+
+	@Override
+	public Set<String> getFreeVariables() {
+		return new HashSet<>();
+	}
+
 }
 

--- a/tools/src/wyvern/target/corewyvernIL/expression/BooleanLiteral.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/BooleanLiteral.java
@@ -45,6 +45,6 @@ public class BooleanLiteral extends AbstractValue {
 	public Set<String> getFreeVariables() {
 		return new HashSet<>();
 	}
-
+	
 }
 

--- a/tools/src/wyvern/target/corewyvernIL/expression/Cast.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/Cast.java
@@ -1,6 +1,5 @@
 package wyvern.target.corewyvernIL.expression;
 
-import java.util.HashSet;
 import java.util.Set;
 
 import wyvern.target.corewyvernIL.astvisitor.ASTVisitor;
@@ -43,6 +42,6 @@ public class Cast extends Expression{
 
 	@Override
 	public Set<String> getFreeVariables() {
-		return new HashSet<>();
+		return toCastExpr.getFreeVariables();
 	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/Cast.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/Cast.java
@@ -1,5 +1,8 @@
 package wyvern.target.corewyvernIL.expression;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import wyvern.target.corewyvernIL.astvisitor.ASTVisitor;
 import wyvern.target.corewyvernIL.support.EvalContext;
 import wyvern.target.corewyvernIL.support.TypeContext;
@@ -10,7 +13,7 @@ public class Cast extends Expression{
 
 	private Expression toCastExpr;
 
-	
+
 	public Cast(Expression toCastExpr, ValueType exprType) {
 		super(exprType);
 		this.toCastExpr = toCastExpr;
@@ -36,5 +39,10 @@ public class Cast extends Expression{
 	public Value interpret(EvalContext ctx) {
 		// TODO Auto-generated method stub
 		return null;
+	}
+
+	@Override
+	public Set<String> getFreeVariables() {
+		return new HashSet<>();
 	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/Expression.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/Expression.java
@@ -1,5 +1,7 @@
 package wyvern.target.corewyvernIL.expression;
 
+import java.util.Set;
+
 import wyvern.target.corewyvernIL.ASTNode;
 import wyvern.target.corewyvernIL.EmitOIR;
 import wyvern.target.corewyvernIL.support.EvalContext;
@@ -8,37 +10,38 @@ import wyvern.target.corewyvernIL.type.ValueType;
 import wyvern.tools.errors.FileLocation;
 
 public abstract class Expression extends ASTNode implements EmitOIR,IExpr {
-	
+
 	private ValueType exprType;
 	@Override
 	public abstract ValueType typeCheck(TypeContext ctx);
 	public abstract Value interpret(EvalContext ctx);
+	public abstract Set<String> getFreeVariables();
 
 	protected Expression (ValueType exprType, FileLocation loc)
 	{
 		super(loc);
 		this.exprType = exprType;
 	}
-	
+
 	protected Expression (ValueType exprType)
 	{
 		this.exprType = exprType;
 	}
-	
+
 	protected Expression (FileLocation loc)
 	{
 		super(loc);
 		// if this constructor is used, exprType must be set later!
 	}
-	
+
 	protected Expression ()
 	{
 		// if this constructor is used, exprType must be set later!
 	}
-	
+
 	public ValueType getExprType() {
 		return exprType;
-	
+
 	}
 	protected void setExprType(ValueType exprType) {
 		this.exprType = exprType;

--- a/tools/src/wyvern/target/corewyvernIL/expression/FieldGet.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/FieldGet.java
@@ -79,6 +79,6 @@ public class FieldGet extends Expression implements Path {
 
 	@Override
 	public Set<String> getFreeVariables() {
-		return new HashSet<>();
+		return objectExpr.getFreeVariables();
 	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/FieldGet.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/FieldGet.java
@@ -1,6 +1,8 @@
 package wyvern.target.corewyvernIL.expression;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 import wyvern.target.corewyvernIL.Environment;
 import wyvern.target.corewyvernIL.astvisitor.ASTVisitor;
@@ -20,7 +22,7 @@ public class FieldGet extends Expression implements Path {
 
 	private IExpr objectExpr;
 	private String fieldName;
-	
+
 	public FieldGet(IExpr objectExpr, String fieldName) {
 		super();
 		this.objectExpr = objectExpr;
@@ -36,11 +38,11 @@ public class FieldGet extends Expression implements Path {
 	public IExpr getObjectExpr() {
 		return objectExpr;
 	}
-	
+
 	public String getName() {
 		return fieldName;
 	}
-	
+
 	@Override
 	public ValueType typeCheck(TypeContext ctx) {
 		ValueType vt = objectExpr.typeCheck(ctx);
@@ -73,5 +75,12 @@ public class FieldGet extends Expression implements Path {
 		if (!(objectExpr instanceof Path))
 			throw new RuntimeException("tried to adapt something that's not a path or type");
 		return new FieldGet((Expression)((Path)objectExpr).adapt(v), fieldName);
+	}
+
+	@Override
+	public Set<String> getFreeVariables() {
+		Set<String> freeVars = objectExpr.getFreeVariables();
+		freeVars.add(fieldName);
+		return freeVars;
 	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/FieldGet.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/FieldGet.java
@@ -79,8 +79,6 @@ public class FieldGet extends Expression implements Path {
 
 	@Override
 	public Set<String> getFreeVariables() {
-		Set<String> freeVars = objectExpr.getFreeVariables();
-		freeVars.add(fieldName);
-		return freeVars;
+		return new HashSet<>();
 	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/FieldSet.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/FieldSet.java
@@ -1,7 +1,6 @@
 package wyvern.target.corewyvernIL.expression;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Set;
 
 import wyvern.target.corewyvernIL.Environment;

--- a/tools/src/wyvern/target/corewyvernIL/expression/FieldSet.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/FieldSet.java
@@ -1,6 +1,8 @@
 package wyvern.target.corewyvernIL.expression;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 import wyvern.target.corewyvernIL.Environment;
 import wyvern.target.corewyvernIL.astvisitor.ASTVisitor;
@@ -22,7 +24,7 @@ public class FieldSet extends Expression {
 	private IExpr objectExpr;
 	private String fieldName;
 	private Expression exprToAssign;
-	
+
 	public FieldSet(ValueType exprType, IExpr objectExpr,
 			String fieldName, Expression exprToAssign) {
 		super(exprType);
@@ -34,36 +36,36 @@ public class FieldSet extends Expression {
 	public IExpr getObjectExpr() {
 		return objectExpr;
 	}
-	
+
 	public String getFieldName() {
 		return fieldName;
 	}
-	
+
 	public Expression getExprToAssign() {
 		return exprToAssign;
 	}
-	
+
 	@Override
 	public ValueType typeCheck(TypeContext ctx) {
-		
+
 		// Figure out types of object and expression.
 		ValueType valTypeExpr = exprToAssign.typeCheck(ctx);
 		StructuralType structTypeObj = objectExpr.typeCheck(ctx).getStructuralType(ctx);
-		
+
 		// Figure out the type of the field.
 		DeclType declTypeField = structTypeObj.findDecl(fieldName, ctx);
 		if (!(declTypeField instanceof VarDeclType))
 			ToolError.reportError(ErrorMessage.CANNOT_BE_ASSIGNED, this,
 								  declTypeField.getName());
 		ValueType valTypeField = ((VarDeclType) declTypeField).getResultType(View.from(objectExpr, ctx));
-		
+
 		// Make sure assigned type is compatible with the field's type.
 		if (!valTypeExpr.isSubtypeOf(valTypeField, ctx))
 			ToolError.reportError(ErrorMessage.ASSIGNMENT_SUBTYPING, this);
 		return valTypeExpr;
-		
+
 	}
-	
+
 	@Override
 	public <T> T acceptVisitor(ASTVisitor <T> emitILVisitor,
 			Environment env, OIREnvironment oirenv) {
@@ -81,13 +83,13 @@ public class FieldSet extends Expression {
 		// find the declaration corresponding to the field
 		Declaration decl = object.findDecl(fieldName);
 		if (decl == null)
-			throw new RuntimeException("Runtime error: trying to set the undeclared field " + fieldName);	
+			throw new RuntimeException("Runtime error: trying to set the undeclared field " + fieldName);
 		if (!(decl instanceof wyvern.target.corewyvernIL.decl.VarDeclaration))
 			throw new RuntimeException("Expected assignment to var field in field set.");
 		VarDeclaration varDecl = (VarDeclaration) decl;
 		Value exprInterpreted = exprToAssign.interpret(ctx);
 		VarDeclaration varDeclUpdated = null;
-		
+
 		// Evaluate the expression in the current context. Update the declaration.
 		// VarDeclaration's constructor needs to take an expression, not a value.
 		// TODO: is this an exhaustive case analysis?
@@ -97,12 +99,12 @@ public class FieldSet extends Expression {
 		else {
 			ToolError.reportError(ErrorMessage.ASSIGNMENT_SUBTYPING, this);
 		}
-		
+
 		// Update object's declarations.
 		object.setDecl(varDeclUpdated);
 		return object;
 	}
-	
+
 	@Override
 	public void doPrettyPrint(Appendable dest, String indent) throws IOException {
 		objectExpr.doPrettyPrint(dest,indent);
@@ -111,5 +113,12 @@ public class FieldSet extends Expression {
 		exprToAssign.doPrettyPrint(dest,indent);
 	}
 
-	
+	@Override
+	public Set<String> getFreeVariables() {
+		Set<String> freeVars = objectExpr.getFreeVariables();
+		freeVars.addAll(exprToAssign.getFreeVariables());
+		freeVars.add(fieldName);
+		return freeVars;
+	}
+
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/FieldSet.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/FieldSet.java
@@ -117,7 +117,6 @@ public class FieldSet extends Expression {
 	public Set<String> getFreeVariables() {
 		Set<String> freeVars = objectExpr.getFreeVariables();
 		freeVars.addAll(exprToAssign.getFreeVariables());
-		freeVars.add(fieldName);
 		return freeVars;
 	}
 

--- a/tools/src/wyvern/target/corewyvernIL/expression/IExpr.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/IExpr.java
@@ -1,6 +1,7 @@
 package wyvern.target.corewyvernIL.expression;
 
 import java.io.IOException;
+import java.util.Set;
 
 import wyvern.target.corewyvernIL.support.EvalContext;
 import wyvern.target.corewyvernIL.support.TypeContext;
@@ -10,4 +11,5 @@ public interface IExpr {
 	public ValueType typeCheck(TypeContext ctx);
 	public abstract Value interpret(EvalContext ctx);
 	void doPrettyPrint(Appendable dest, String indent) throws IOException;
+	public abstract Set<String> getFreeVariables();
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/IntegerLiteral.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/IntegerLiteral.java
@@ -58,10 +58,11 @@ public class IntegerLiteral extends AbstractValue {
 			Environment env, OIREnvironment oirenv) {
 		return emitILVisitor.visit(env, oirenv, this);
 	}
-
+	
 	@Override
 	public Set<String> getFreeVariables() {
 		return new HashSet<>();
 	}
+	
 
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/IntegerLiteral.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/IntegerLiteral.java
@@ -1,6 +1,8 @@
 package wyvern.target.corewyvernIL.expression;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 import wyvern.target.corewyvernIL.Environment;
 import wyvern.target.corewyvernIL.astvisitor.ASTVisitor;
@@ -10,7 +12,7 @@ import wyvern.target.corewyvernIL.type.ValueType;
 import wyvern.target.oir.OIREnvironment;
 
 public class IntegerLiteral extends AbstractValue {
-	
+
 	@Override
 	public int hashCode() {
 		return value;
@@ -41,7 +43,7 @@ public class IntegerLiteral extends AbstractValue {
 	public void doPrettyPrint(Appendable dest, String indent) throws IOException {
 		dest.append(Integer.toString(value));
 	}
-	
+
 	public int getValue() {
 		return value;
 	}
@@ -55,6 +57,11 @@ public class IntegerLiteral extends AbstractValue {
 	public <T> T acceptVisitor(ASTVisitor <T> emitILVisitor,
 			Environment env, OIREnvironment oirenv) {
 		return emitILVisitor.visit(env, oirenv, this);
+	}
+
+	@Override
+	public Set<String> getFreeVariables() {
+		return new HashSet<>();
 	}
 
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/JavaValue.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/JavaValue.java
@@ -1,7 +1,9 @@
 package wyvern.target.corewyvernIL.expression;
 
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 import wyvern.target.corewyvernIL.Environment;
 import wyvern.target.corewyvernIL.astvisitor.ASTVisitor;
@@ -15,7 +17,7 @@ public class JavaValue extends AbstractValue implements Invokable {
 	// FObject is part of a non-Wyvern-specific Java interop library
 	// e.g. it could be re-used by Plaid or some future language design
 	private FObject foreignObject;
-	
+
 	public JavaValue(FObject foreignObject, ValueType exprType) {
 		super(exprType);
 		this.foreignObject = foreignObject;
@@ -74,6 +76,11 @@ public class JavaValue extends AbstractValue implements Invokable {
 	@Override
 	public ValueType typeCheck(TypeContext ctx) {
 		return this.getExprType();
+	}
+
+	@Override
+	public Set<String> getFreeVariables() {
+		throw new RuntimeException("Free variables of a JavaValue not yet implemented.");
 	}
 
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/JavaValue.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/JavaValue.java
@@ -1,6 +1,5 @@
 package wyvern.target.corewyvernIL.expression;
 
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;

--- a/tools/src/wyvern/target/corewyvernIL/expression/JavaValue.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/JavaValue.java
@@ -1,5 +1,6 @@
 package wyvern.target.corewyvernIL.expression;
 
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -78,7 +79,7 @@ public class JavaValue extends AbstractValue implements Invokable {
 
 	@Override
 	public Set<String> getFreeVariables() {
-		throw new RuntimeException("Free variables of a JavaValue not yet implemented.");
+		return new HashSet<>();
 	}
 
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/Let.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/Let.java
@@ -1,6 +1,7 @@
 package wyvern.target.corewyvernIL.expression;
 
 import java.io.IOException;
+import java.util.Set;
 
 import wyvern.target.corewyvernIL.Environment;
 import wyvern.target.corewyvernIL.astvisitor.ASTVisitor;
@@ -14,7 +15,7 @@ public class Let extends Expression {
 	private String varName;
 	private Expression toReplace;
 	private Expression inExpr;
-	
+
 	public Let(String varName, Expression toReplace, Expression inExpr) {
 		super();
 		this.varName = varName;
@@ -27,15 +28,15 @@ public class Let extends Expression {
 	public String getVarName() {
 		return varName;
 	}
-	
+
 	public Expression getToReplace() {
 		return toReplace;
 	}
-	
+
 	public Expression getInExpr() {
 		return inExpr;
 	}
-	
+
 	@Override
 	public ValueType typeCheck(TypeContext ctx) {
 		ValueType t = toReplace.typeCheck(ctx);
@@ -63,5 +64,13 @@ public class Let extends Expression {
 	public Value interpret(EvalContext ctx) {
 		Value v = toReplace.interpret(ctx);
 		return inExpr.interpret(ctx.extend(varName, v));
+	}
+
+	@Override
+	public Set<String> getFreeVariables() {
+		Set<String> boundVars = toReplace.getFreeVariables();
+		Set<String> freeVars = inExpr.getFreeVariables();
+		freeVars.removeAll(boundVars);
+		return freeVars;
 	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/Let.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/Let.java
@@ -70,8 +70,9 @@ public class Let extends Expression {
 	public Set<String> getFreeVariables() {
 		
 		// Get free variables in the sub-expressions.
-		Set<String> freeVars = toReplace.getFreeVariables();
-		freeVars.addAll(inExpr.getFreeVariables());
+		Set<String> freeVars = inExpr.getFreeVariables();
+		freeVars.remove(varName);
+		freeVars.addAll(toReplace.getFreeVariables());
 		
 		// Remove the name that just became bound.
 		freeVars.remove(varName);

--- a/tools/src/wyvern/target/corewyvernIL/expression/Let.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/Let.java
@@ -68,9 +68,13 @@ public class Let extends Expression {
 
 	@Override
 	public Set<String> getFreeVariables() {
-		Set<String> boundVars = toReplace.getFreeVariables();
-		Set<String> freeVars = inExpr.getFreeVariables();
-		freeVars.removeAll(boundVars);
+		
+		// Get free variables in the sub-expressions.
+		Set<String> freeVars = toReplace.getFreeVariables();
+		freeVars.addAll(inExpr.getFreeVariables());
+		
+		// Remove the name that just became bound.
+		freeVars.remove(varName);
 		return freeVars;
 	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/Literal.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/Literal.java
@@ -1,5 +1,8 @@
 package wyvern.target.corewyvernIL.expression;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import wyvern.target.corewyvernIL.type.ValueType;
 
 public abstract class Literal extends AbstractValue {

--- a/tools/src/wyvern/target/corewyvernIL/expression/Literal.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/Literal.java
@@ -1,8 +1,5 @@
 package wyvern.target.corewyvernIL.expression;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import wyvern.target.corewyvernIL.type.ValueType;
 
 public abstract class Literal extends AbstractValue {

--- a/tools/src/wyvern/target/corewyvernIL/expression/Match.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/Match.java
@@ -8,6 +8,7 @@ import wyvern.target.corewyvernIL.Environment;
 import wyvern.target.corewyvernIL.astvisitor.ASTVisitor;
 import wyvern.target.corewyvernIL.support.EvalContext;
 import wyvern.target.corewyvernIL.support.TypeContext;
+import wyvern.target.corewyvernIL.type.NominalType;
 import wyvern.target.corewyvernIL.type.ValueType;
 import wyvern.target.oir.OIREnvironment;
 
@@ -59,6 +60,13 @@ public class Match extends Expression {
 		Set<String> freeVars = matchExpr.getFreeVariables();
 		for (Case c : cases) {
 			freeVars.addAll(c.getBody().getFreeVariables());
+			freeVars.remove(c.getVarName());
+			
+			// Add variable at the root of the path of the NominalType
+			// Look up that variable to get the tag to do the tag check.
+			// Path p = c.getPattern().getPath();
+			// if p returns y.f.x, the variable at the root of the path = y?
+			
 		}
 		freeVars.addAll(elseExpr.getFreeVariables());
 		return freeVars;

--- a/tools/src/wyvern/target/corewyvernIL/expression/Match.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/Match.java
@@ -1,6 +1,8 @@
 package wyvern.target.corewyvernIL.expression;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import wyvern.target.corewyvernIL.Case;
 import wyvern.target.corewyvernIL.Environment;
@@ -15,7 +17,7 @@ public class Match extends Expression {
 	private Expression matchExpr;
 	private Expression elseExpr;
 	private List<Case> cases;
-	
+
 	public Match(Expression matchExpr, Expression elseExpr, List<Case> cases) {
 		super();
 		this.matchExpr = matchExpr;
@@ -26,15 +28,15 @@ public class Match extends Expression {
 	public Expression getMatchExpr() {
 		return matchExpr;
 	}
-	
+
 	public Expression getElseExpr() {
 		return elseExpr;
 	}
-	
+
 	public List<Case> getCases() {
 		return cases;
 	}
-	
+
 	@Override
 	public ValueType typeCheck(TypeContext env) {
 		// TODO Auto-generated method stub
@@ -51,5 +53,15 @@ public class Match extends Expression {
 	public Value interpret(EvalContext ctx) {
 		// TODO Auto-generated method stub
 		return null;
+	}
+
+	@Override
+	public Set<String> getFreeVariables() {
+		Set<String> freeVars = matchExpr.getFreeVariables();
+		for (Case c : cases) {
+			freeVars.addAll(c.getBody().getFreeVariables());
+		}
+		freeVars.addAll(elseExpr.getFreeVariables());
+		return freeVars;
 	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/Match.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/Match.java
@@ -1,6 +1,5 @@
 package wyvern.target.corewyvernIL.expression;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 

--- a/tools/src/wyvern/target/corewyvernIL/expression/MethodCall.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/MethodCall.java
@@ -109,7 +109,7 @@ public class MethodCall extends Expression {
 	@Override
 	public Set<String> getFreeVariables() {
 		Set<String> freeVars = objectExpr.getFreeVariables();
-		freeVars.add(methodName);
+		freeVars.add(this.methodName);
 		for (Expression arg : args) {
 			freeVars.addAll(arg.getFreeVariables());
 		}

--- a/tools/src/wyvern/target/corewyvernIL/expression/MethodCall.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/MethodCall.java
@@ -13,7 +13,6 @@ import wyvern.target.corewyvernIL.support.EvalContext;
 import wyvern.target.corewyvernIL.support.TypeContext;
 import wyvern.target.corewyvernIL.support.View;
 import wyvern.target.corewyvernIL.type.StructuralType;
-import wyvern.target.corewyvernIL.type.Type;
 import wyvern.target.corewyvernIL.type.ValueType;
 import wyvern.target.oir.OIREnvironment;
 import wyvern.tools.errors.ErrorMessage;

--- a/tools/src/wyvern/target/corewyvernIL/expression/MethodCall.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/MethodCall.java
@@ -108,7 +108,6 @@ public class MethodCall extends Expression {
 	@Override
 	public Set<String> getFreeVariables() {
 		Set<String> freeVars = objectExpr.getFreeVariables();
-		freeVars.add(this.methodName);
 		for (Expression arg : args) {
 			freeVars.addAll(arg.getFreeVariables());
 		}

--- a/tools/src/wyvern/target/corewyvernIL/expression/New.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/New.java
@@ -1,9 +1,11 @@
 package wyvern.target.corewyvernIL.expression;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import wyvern.target.corewyvernIL.Environment;
@@ -92,7 +94,7 @@ public class New extends Expression {
 
 		ValueType type = getExprType();
 		if (hasDelegate) {
-			ValueType delegateObjectType = ctx.lookup(delegateDeclaration.getFieldName()); 
+			ValueType delegateObjectType = ctx.lookup(delegateDeclaration.getFieldName());
 			StructuralType delegateStructuralType = delegateObjectType.getStructuralType(thisCtx);
 			// new defined declaration will override delegate object's method definition if they had subType relationship
 			for (DeclType declType : delegateStructuralType.getDeclTypes()) {
@@ -129,5 +131,17 @@ public class New extends Expression {
 
 	private List<Declaration> decls_ExceptDelegate() {
 		return decls.stream().filter(x->x != delegateDeclaration).collect(Collectors.toList());
+	}
+
+	@Override
+	public Set<String> getFreeVariables() {
+		Set<String> freeVars = new HashSet<>();
+		if (hasDelegate) {
+			freeVars.addAll(delegateDeclaration.getFreeVariables());
+		}
+		for (Declaration decl : decls) {
+			freeVars.addAll(decl.getFreeVariables());
+		}
+		return freeVars;
 	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/RationalLiteral.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/RationalLiteral.java
@@ -1,5 +1,8 @@
 package wyvern.target.corewyvernIL.expression;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import wyvern.target.corewyvernIL.Environment;
 import wyvern.target.corewyvernIL.astvisitor.ASTVisitor;
 import wyvern.target.corewyvernIL.support.TypeContext;
@@ -7,10 +10,10 @@ import wyvern.target.corewyvernIL.type.ValueType;
 import wyvern.target.oir.OIREnvironment;
 
 public class RationalLiteral extends AbstractValue {
-	
+
 	private int numerator;
 	private int denominator;
-	
+
 	public RationalLiteral(int numerator, int denominator) {
 		super(null);
 		this.numerator = numerator;
@@ -20,15 +23,15 @@ public class RationalLiteral extends AbstractValue {
 	public int getNumerator() {
 		return numerator;
 	}
-	
+
 	public void setNumerator(int numerator) {
 		this.numerator = numerator;
 	}
-	
+
 	public int getDenominator() {
 		return denominator;
 	}
-	
+
 	public void setDenominator(int denominator) {
 		this.denominator = denominator;
 	}
@@ -44,4 +47,9 @@ public class RationalLiteral extends AbstractValue {
 			Environment env, OIREnvironment oirenv) {
 		return emitILVisitor.visit(env, oirenv, this);
 	}
+
+	public Set<String> getFreeVariables() {
+		return new HashSet<>();
+	}
+
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/StringLiteral.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/StringLiteral.java
@@ -1,6 +1,8 @@
 package wyvern.target.corewyvernIL.expression;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 import wyvern.target.corewyvernIL.Environment;
 import wyvern.target.corewyvernIL.astvisitor.ASTVisitor;
@@ -10,9 +12,9 @@ import wyvern.target.corewyvernIL.type.ValueType;
 import wyvern.target.oir.OIREnvironment;
 
 public class StringLiteral extends Literal {
-	
+
 	private java.lang.String value;
-	
+
 	public StringLiteral(java.lang.String value) {
 		super(null);
 		this.value = value;
@@ -59,10 +61,14 @@ public class StringLiteral extends Literal {
 	public void doPrettyPrint(Appendable dest, String indent) throws IOException {
 		dest.append('"').append(value).append('"');
 	}
-	
+
 	@Override
 	public <T> T acceptVisitor(ASTVisitor <T> emitILVisitor,
 			Environment env, OIREnvironment oirenv) {
 		return emitILVisitor.visit(env, oirenv, this);
+	}
+
+	public Set<String> getFreeVariables() {
+		return new HashSet<>();
 	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/StringLiteral.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/StringLiteral.java
@@ -68,7 +68,10 @@ public class StringLiteral extends Literal {
 		return emitILVisitor.visit(env, oirenv, this);
 	}
 
+	@Override
 	public Set<String> getFreeVariables() {
 		return new HashSet<>();
 	}
+
+	
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/Variable.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/Variable.java
@@ -1,6 +1,8 @@
 package wyvern.target.corewyvernIL.expression;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 import wyvern.target.corewyvernIL.Environment;
 import wyvern.target.corewyvernIL.astvisitor.ASTVisitor;
@@ -43,7 +45,7 @@ public class Variable extends Expression implements Path {
 	public void doPrettyPrint(Appendable dest, String indent) throws IOException {
 		dest.append(name);
 	}
-	
+
 	public Variable(String name) {
 		super();
 		this.name = name;
@@ -73,5 +75,11 @@ public class Variable extends Expression implements Path {
 	@Override
 	public Path adapt(View v) {
 		return v.adapt(this);
+	}
+
+	public Set<String> getFreeVariables() {
+		Set<String> freeVars = new HashSet<>();
+		freeVars.add(this.getName());
+		return freeVars;
 	}
 }

--- a/tools/src/wyvern/tools/tests/FreeVars.java
+++ b/tools/src/wyvern/tools/tests/FreeVars.java
@@ -1,0 +1,119 @@
+package wyvern.tools.tests;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import wyvern.target.corewyvernIL.FormalArg;
+import wyvern.target.corewyvernIL.decl.Declaration;
+import wyvern.target.corewyvernIL.decl.DefDeclaration;
+import wyvern.target.corewyvernIL.decltype.DeclType;
+import wyvern.target.corewyvernIL.decltype.VarDeclType;
+import wyvern.target.corewyvernIL.expression.Expression;
+import wyvern.target.corewyvernIL.expression.FieldGet;
+import wyvern.target.corewyvernIL.expression.IntegerLiteral;
+import wyvern.target.corewyvernIL.expression.Let;
+import wyvern.target.corewyvernIL.expression.New;
+import wyvern.target.corewyvernIL.expression.Variable;
+import wyvern.target.corewyvernIL.support.GenContext;
+import wyvern.target.corewyvernIL.support.TypeContext;
+import wyvern.target.corewyvernIL.type.NominalType;
+import wyvern.target.corewyvernIL.type.StructuralType;
+import wyvern.target.corewyvernIL.type.ValueType;
+import wyvern.tools.imports.extensions.WyvernResolver;
+import wyvern.tools.parsing.coreparser.ParseException;
+import wyvern.tools.tests.suites.RegressionTests;
+import wyvern.tools.tests.tagTests.TestUtil;
+import wyvern.tools.typedAST.core.binding.NameBindingImpl;
+import wyvern.tools.typedAST.core.declarations.DeclSequence;
+import wyvern.tools.typedAST.interfaces.ExpressionAST;
+import wyvern.tools.types.QualifiedType;
+import wyvern.tools.types.TypeUtils;
+import wyvern.tools.types.extensions.Arrow;
+
+@Category(RegressionTests.class)
+public class FreeVars {
+ 	
+	private static final String BASE_PATH = TestUtil.BASE_PATH;
+	private static final String PATH = BASE_PATH + "modules/module/";
+	
+	private NominalType systemInt() {
+		return new NominalType("system", "Int");
+	}
+	
+    @BeforeClass public static void setupResolver() {
+    	TestUtil.setPaths();
+		WyvernResolver.getInstance().addPath(PATH);
+    }
+
+	@Test
+    public void testMethodDefinition() throws ParseException {
+		
+		// def meth() : system.Int
+		//    x
+		
+		DefDeclaration defDecl = new DefDeclaration("method", new ArrayList<>(), systemInt(),
+				new Variable("x"));
+		
+		Set<String> freeVars = defDecl.getFreeVariables();
+		Assert.assertTrue("x is a free variable in this method.", freeVars.contains("x"));
+		Assert.assertEquals("x is the only free variable in this method.", freeVars.size(), 1);
+	}
+	
+	@Test
+	public void testMethodWithFormalArgs() throws ParseException {
+		
+		// def meth(x : Int) : system.Int
+		//     x = y
+		//     x
+
+		Let varAssign = new Let("x", new Variable("y"), new Variable("x"));
+		DefDeclaration defDecl = new DefDeclaration("method", new ArrayList<>(), systemInt(), varAssign);
+		
+		Set<String> freeVars = defDecl.getFreeVariables();
+
+		Assert.assertTrue("y is a free variable in this method.", freeVars.contains("y"));
+		Assert.assertFalse("x is not a free variable in this method.", freeVars.contains("x"));
+		Assert.assertEquals("y is the only free variable in this method.", freeVars.size(), 1);	
+	}
+	
+	@Test
+	public void testDefInsideLet() {
+		
+		// var y : system.Int = 5
+		// def meth (x : Int) : system.Int
+		//     x = y
+		//     x
+		
+		// The body of the method.
+		Let assignYtoX = new Let("x", new Variable("y"), new Variable("x"));
+		
+		// The method declaration, wrapped inside a New expression.
+		LinkedList<Declaration> decls = new LinkedList<>();	
+		DefDeclaration defDecl = new DefDeclaration("method", new ArrayList<>(), systemInt(), assignYtoX);
+		decls.add(defDecl);
+		
+		// The type of the declaration sequence.
+		DeclType varDeclType = new VarDeclType("y", systemInt());
+		List<DeclType> declTypes = new LinkedList<>();
+		declTypes.add(varDeclType);
+		StructuralType typeOfDecls = new StructuralType("this", declTypes, true);
+		
+		// Turn into a New expression.
+		New newDecls = new New(decls, "this", typeOfDecls);
+		
+		// Enclose with the declaration of y.
+		Let assign5toY = new Let("y", new IntegerLiteral(5), newDecls);
+		
+		// Check the free variables.
+		Set<String> freeVars = assign5toY.getFreeVariables();
+		Assert.assertTrue("There are no free variables in this program.", freeVars.isEmpty());
+	}
+	
+}


### PR DESCRIPTION
This attempts to solve #76 

A getFreeVariables() method has been declared in the following places:
* corewyvernIL.expression.Expression
* corewyvernIL.expression.IExpr (this one is needed for FieldSet and FieldGet, which contain IExpr fields as well as regular Expression fields)
* corewyvernIL.decl.Declaration

There are some tests in a new FreeVars file which tests the new functions out on a few code fragments.