### PR TITLE
adding a test for if statements

### DIFF
--- a/tools/src/wyvern/target/corewyvernIL/expression/MethodCall.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/MethodCall.java
@@ -78,10 +78,12 @@ public class MethodCall extends Expression {
 		for (int i = 0; i < args.size(); ++i) {
 			Expression e = args.get(i);
 			ValueType argType = ddt.getFormalArgs().get(i).getType().adapt(v);
-			ValueType actualType = e.typeCheck(ctx);
+			String name = ddt.getFormalArgs().get(i).getName();
+			ValueType actualType = e.typeCheck(ctx); 
 			if (!actualType.isSubtypeOf(argType, ctx)) {
 				ToolError.reportError(ErrorMessage.ACTUAL_FORMAL_TYPE_MISMATCH, this, actualType.toString(), argType.toString());
             }
+			ctx = ctx.extend(name, argType);
 		}
 		// compute result type
 		this.setExprType(ddt.getResultType(v));

--- a/tools/src/wyvern/tools/tests/ILTests.java
+++ b/tools/src/wyvern/tools/tests/ILTests.java
@@ -1164,4 +1164,126 @@ public class ILTests {
         IntegerLiteral five = new IntegerLiteral(5);
         Assert.assertEquals(five, v);
     }
+
+    @Test
+    public void testDependentType2() throws ParseException {
+
+        String source = ""
+                      + "type IntHolder\n"
+                      + "    type heldType = system.Int\n"
+                      + "    val element: this.heldType\n\n"
+
+                      + "def Identity(holder: IntHolder, passedType: holder.heldType) : holder.heldType\n"
+                      + "    holder.element\n\n"
+
+                      + "val five: IntHolder = new\n"
+                      + "    type heldType = system.Int\n"
+                      + "    val element: this.heldType = 5\n\n"
+
+                      + "Identity(five, 5)";
+
+        ExpressionAST ast = (ExpressionAST) TestUtil.getNewAST(source);
+
+        GenContext genCtx = TestUtil.getStandardGenContext();
+        Expression program = ast.generateIL(genCtx, null);
+
+        ValueType t = program.typeCheck(TestUtil.getStandardTypeContext());
+
+
+        Value v = program.interpret(EvalContext.empty());
+        IntegerLiteral five = new IntegerLiteral(5);
+        Assert.assertEquals(five, v);
+    }
+
+    @Test
+    public void testIfStatement() throws ParseException {
+
+        String source = ""
+                      + "type Body\n"
+                      + "    type T = system.Int\n"
+                      + "    def apply(): this.T \n\n"
+
+                      + "type Boolean\n"
+                      + "   def iff(thenFn: Body, elseFn: Body) : thenFn.T \n\n"
+
+                      + "val true = new \n"
+                      + "    def iff(thenFn: Body, elseFn: Body): thenFn.T \n\n"
+                      + "        thenFn.apply()\n\n"
+
+                      + "val false = new \n"
+                      + "    def iff(thenFn: Body, elseFn: Body): thenFn.T \n"
+                      + "        elseFn.apply()\n\n"
+
+                      + "def ifSt(bool: Boolean, thenFn: Body, elseFn: Body): thenFn.T \n"
+                      + "    bool.iff(thenFn, elseFn) \n\n"
+
+                      + "val IntegerFive = new \n"
+                      + "   type T = system.Int \n"
+                      + "   def apply(): this.T \n"
+                      + "       5 \n\n"
+
+                      + "val IntegerTen = new \n"
+                      + "   type T = system.Int \n"
+                      + "   def apply(): this.T \n"
+                      + "       10 \n\n"
+
+                      + "ifSt(true, IntegerTen, IntegerFive)";
+
+        ExpressionAST ast = (ExpressionAST) TestUtil.getNewAST(source);
+
+        GenContext genCtx = TestUtil.getStandardGenContext();
+        Expression program = ast.generateIL(genCtx, null);
+
+        ValueType t = program.typeCheck(TestUtil.getStandardTypeContext());
+        Value v = program.interpret(EvalContext.empty());
+
+        IntegerLiteral ten = new IntegerLiteral(10);
+        Assert.assertEquals(ten, v);
+    }
+
+    @Test
+    public void testIfStatement2() throws ParseException {
+
+        String source = ""
+                      + "type Body\n"
+                      + "    type T = system.Int\n"
+                      + "    def apply(): this.T \n\n"
+
+                      + "type Boolean\n"
+                      + "   def iff(thenFn: Body, elseFn: Body) : thenFn.T \n\n"
+
+                      + "val true = new \n"
+                      + "    def iff(thenFn: Body, elseFn: Body): thenFn.T \n\n"
+                      + "        thenFn.apply()\n\n"
+
+                      + "val false = new \n"
+                      + "    def iff(thenFn: Body, elseFn: Body): thenFn.T \n"
+                      + "        elseFn.apply()\n\n"
+
+                      + "def ifSt(bool: Boolean, thenFn: Body, elseFn: Body): thenFn.T \n"
+                      + "    bool.iff(thenFn, elseFn) \n\n"
+
+                      + "val IntegerFive = new \n"
+                      + "   type T = system.Int \n"
+                      + "   def apply(): this.T \n"
+                      + "       5 \n\n"
+
+                      + "val IntegerTen = new \n"
+                      + "   type T = system.Int \n"
+                      + "   def apply(): this.T \n"
+                      + "       10 \n\n"
+
+                      + "ifSt(false, IntegerTen, IntegerFive)";
+
+        ExpressionAST ast = (ExpressionAST) TestUtil.getNewAST(source);
+
+        GenContext genCtx = TestUtil.getStandardGenContext();
+        Expression program = ast.generateIL(genCtx, null);
+
+        ValueType t = program.typeCheck(TestUtil.getStandardTypeContext());
+        Value v = program.interpret(EvalContext.empty());
+
+        IntegerLiteral five = new IntegerLiteral(5);
+        Assert.assertEquals(five, v);
+    }
 }


### PR DESCRIPTION
Hi there!

The first test I added, `testDependentType2`, checks to make sure that you can have dependently typed arguments. As I noted in my last PR https://github.com/wyvernlang/wyvern/pull/79 , dependent types could only be used as return values until this PR. I made changes to https://github.com/wyvernlang/wyvern/blob/a2d0b661f6e0540ae6be8ea539c0f2da74805378/tools/src/wyvern/target/corewyvernIL/expression/MethodCall.java to get that test to pass.

After, using the new dependent types, I wrote a pure-Wyvern `if-else` construct. The two tests pass.
However, note that my `if Body` construct has a type member of `system.Int`. This limits the if statement to only return `int`s :sob: 

The reason for this is that abstract type members aren't implemented yet, so I could say write this, for example:

    type Body
        type T
        def apply(): this.T

That fails to parse currently. Perhaps getting that to work can be my next task, since it would allow for custom control structures.  
¯\\_(ツ)_/¯