### PR TITLE
Make EvalContext extend TypeContext

### DIFF
--- a/tools/src/wyvern/target/corewyvernIL/expression/BooleanLiteral.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/BooleanLiteral.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import wyvern.target.corewyvernIL.Environment;
 import wyvern.target.corewyvernIL.astvisitor.ASTVisitor;
 import wyvern.target.corewyvernIL.support.TypeContext;
+import wyvern.target.corewyvernIL.support.Util;
 import wyvern.target.corewyvernIL.type.ValueType;
 import wyvern.target.oir.OIREnvironment;
 
@@ -30,8 +31,7 @@ public class BooleanLiteral extends AbstractValue {
 
     @Override
     public ValueType typeCheck(TypeContext env) {
-        // TODO Auto-generated method stub
-        return null;
+        return Util.booleanType();
     }
 
 	@Override
@@ -45,6 +45,10 @@ public class BooleanLiteral extends AbstractValue {
 	public Set<String> getFreeVariables() {
 		return new HashSet<>();
 	}
-	
+
+	@Override
+	public ValueType getType() {
+		return Util.booleanType();
+	}
 }
 

--- a/tools/src/wyvern/target/corewyvernIL/expression/IntegerLiteral.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/IntegerLiteral.java
@@ -63,6 +63,10 @@ public class IntegerLiteral extends AbstractValue {
 	public Set<String> getFreeVariables() {
 		return new HashSet<>();
 	}
-	
 
+
+	@Override
+	public ValueType getType() {
+		return Util.intType();
+	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/JavaValue.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/JavaValue.java
@@ -82,4 +82,8 @@ public class JavaValue extends AbstractValue implements Invokable {
 		return new HashSet<>();
 	}
 
+	@Override
+	public ValueType getType() {
+		return this.getExprType();
+	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/Let.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/Let.java
@@ -71,11 +71,10 @@ public class Let extends Expression {
 		
 		// Get free variables in the sub-expressions.
 		Set<String> freeVars = inExpr.getFreeVariables();
+		// Remove the name that just became bound.
 		freeVars.remove(varName);
 		freeVars.addAll(toReplace.getFreeVariables());
 		
-		// Remove the name that just became bound.
-		freeVars.remove(varName);
 		return freeVars;
 	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/Match.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/Match.java
@@ -62,10 +62,11 @@ public class Match extends Expression {
 			freeVars.addAll(c.getBody().getFreeVariables());
 			freeVars.remove(c.getVarName());
 			
+			// TODO: fix when Match is implemented
 			// Add variable at the root of the path of the NominalType
 			// Look up that variable to get the tag to do the tag check.
 			// Path p = c.getPattern().getPath();
-			// if p returns y.f.x, the variable at the root of the path = y?
+			// if p returns y.f.x, the variable at the root of the path = y
 			
 		}
 		freeVars.addAll(elseExpr.getFreeVariables());

--- a/tools/src/wyvern/target/corewyvernIL/expression/New.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/New.java
@@ -142,6 +142,7 @@ public class New extends Expression {
 		for (Declaration decl : decls) {
 			freeVars.addAll(decl.getFreeVariables());
 		}
+		freeVars.remove(selfName);
 		return freeVars;
 	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/New.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/New.java
@@ -94,7 +94,7 @@ public class New extends Expression {
 
 		ValueType type = getExprType();
 		if (hasDelegate) {
-			ValueType delegateObjectType = ctx.lookup(delegateDeclaration.getFieldName());
+			ValueType delegateObjectType = ctx.lookupType(delegateDeclaration.getFieldName());
 			StructuralType delegateStructuralType = delegateObjectType.getStructuralType(thisCtx);
 			// new defined declaration will override delegate object's method definition if they had subType relationship
 			for (DeclType declType : delegateStructuralType.getDeclTypes()) {

--- a/tools/src/wyvern/target/corewyvernIL/expression/ObjectValue.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/ObjectValue.java
@@ -25,7 +25,7 @@ public class ObjectValue extends New implements Invokable {
 		evalCtx = ctx.extend(selfName, this);
 		hasDelegate = delegateDecl != null ? true : false; 
 		if (hasDelegate) {
-			delegateTarget = (ObjectValue)ctx.lookup(delegateDecl.getFieldName());
+			delegateTarget = (ObjectValue)ctx.lookupValue(delegateDecl.getFieldName());
 		}
 	}
 

--- a/tools/src/wyvern/target/corewyvernIL/expression/ObjectValue.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/ObjectValue.java
@@ -70,5 +70,9 @@ public class ObjectValue extends New implements Invokable {
 		}
 		throw new RuntimeException("cannot set decl " + decl.getName());
 	}
-	
+
+	@Override
+	public ValueType getType() {
+		return getExprType();
+	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/RationalLiteral.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/RationalLiteral.java
@@ -52,4 +52,9 @@ public class RationalLiteral extends AbstractValue {
 		return new HashSet<>();
 	}
 
+	@Override
+	public ValueType getType() {
+		// TODO Auto-generated method stub
+		return null;
+	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/StringLiteral.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/StringLiteral.java
@@ -73,5 +73,9 @@ public class StringLiteral extends Literal {
 		return new HashSet<>();
 	}
 
-	
+
+	@Override
+	public ValueType getType() {
+		return Util.stringType();
+	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/Value.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/Value.java
@@ -1,4 +1,7 @@
 package wyvern.target.corewyvernIL.expression;
 
+import wyvern.target.corewyvernIL.type.ValueType;
+
 public interface Value {
+    ValueType getType();
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/Variable.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/Variable.java
@@ -57,7 +57,7 @@ public class Variable extends Expression implements Path {
 
 	@Override
 	public ValueType typeCheck(TypeContext env) {
-		return env.lookup(name);
+		return env.lookupType(name);
 	}
 
 	@Override
@@ -68,7 +68,7 @@ public class Variable extends Expression implements Path {
 
 	@Override
 	public Value interpret(EvalContext ctx) {
-		Value exp =  ctx.lookup(name);
+		Value exp =  ctx.lookupValue(name);
 		return exp;
 	}
 

--- a/tools/src/wyvern/target/corewyvernIL/support/EmptyGenContext.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/EmptyGenContext.java
@@ -9,7 +9,7 @@ public class EmptyGenContext extends GenContext {
 	}
 
 	@Override
-	public ValueType lookup(String varName) {
+	public ValueType lookupType(String varName) {
 		throw new RuntimeException("Variable " + varName + " not found");
 	}
 

--- a/tools/src/wyvern/target/corewyvernIL/support/EmptyTypeContext.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/EmptyTypeContext.java
@@ -3,7 +3,7 @@ package wyvern.target.corewyvernIL.support;
 import wyvern.target.corewyvernIL.type.ValueType;
 
 public class EmptyTypeContext extends TypeContext {
-	public ValueType lookup(String varName) {
+	public ValueType lookupType(String varName) {
 		throw new RuntimeException("Variable " + varName + " not found");
 	}
 

--- a/tools/src/wyvern/target/corewyvernIL/support/EmptyValContext.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/EmptyValContext.java
@@ -3,7 +3,7 @@ package wyvern.target.corewyvernIL.support;
 import wyvern.target.corewyvernIL.expression.Value;
 
 public class EmptyValContext extends EvalContext {
-	public Value lookup(String varName) {
+	public Value lookupValue(String varName) {
 		throw new RuntimeException("Variable " + varName + " not found");
 	}
 
@@ -14,6 +14,11 @@ public class EmptyValContext extends EvalContext {
 
 	@Override
 	public String endToString() {
+		return null;
+	}
+
+	@Override
+	protected TypeContext getNext() {
 		return null;
 	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/support/EvalContext.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/EvalContext.java
@@ -10,8 +10,7 @@ public abstract class EvalContext extends TypeContext {
 
 	@Override
 	public ValueType lookupType(String varName) {
-		// TODO: return appropriate ValueType
-		throw new RuntimeException("Cannot look up type from EvalContext.");
+		return lookupValue(varName).getType();
 	}
 
 	public abstract Value lookupValue(String varName);

--- a/tools/src/wyvern/target/corewyvernIL/support/EvalContext.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/EvalContext.java
@@ -1,13 +1,20 @@
 package wyvern.target.corewyvernIL.support;
 
 import wyvern.target.corewyvernIL.expression.Value;
+import wyvern.target.corewyvernIL.type.ValueType;
 
-public abstract class EvalContext {
+public abstract class EvalContext extends TypeContext {
 	public EvalContext extend(String var, Value v) {
 		return new VarEvalContext(var, v, this);
 	}
-	
-	public abstract Value lookup(String varName);
+
+	@Override
+	public ValueType lookupType(String varName) {
+		// TODO: return appropriate ValueType
+		throw new RuntimeException("Cannot look up type from EvalContext.");
+	}
+
+	public abstract Value lookupValue(String varName);
 	
 	public abstract EvalContext combine(EvalContext ctx);
 	

--- a/tools/src/wyvern/target/corewyvernIL/support/GenContext.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/GenContext.java
@@ -78,7 +78,7 @@ public abstract class GenContext extends TypeContext {
 	 * Internal recursive version.
 	 * 
 	 * @param varName the method name
-	 * @param origCtx the original context the lookup was performed in
+	 * @param origCtx the original context the lookupValue was performed in
 	 * @return the CallableExprGenerator
 	 */
 	abstract CallableExprGenerator getCallableExprRec(String varName, GenContext origCtx);

--- a/tools/src/wyvern/target/corewyvernIL/support/GenUtil.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/GenUtil.java
@@ -115,7 +115,7 @@ public class GenUtil {
             return Util.stringType();
         }
         
-		StructuralTypesFromJava type = (StructuralTypesFromJava) ctx.lookup(javaTypesObjectName);
+		StructuralTypesFromJava type = (StructuralTypesFromJava) ctx.lookupType(javaTypesObjectName);
 		return type.getJavaType(javaClass, ctx);
 	}
 	// out of date

--- a/tools/src/wyvern/target/corewyvernIL/support/MethodGenContext.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/MethodGenContext.java
@@ -25,8 +25,8 @@ public class MethodGenContext extends GenContext {
 	}
 
 	@Override
-	public ValueType lookup(String varName) {
-		return getNext().lookup(varName);
+	public ValueType lookupType(String varName) {
+		return getNext().lookupType(varName);
 	}
 
 	@Override

--- a/tools/src/wyvern/target/corewyvernIL/support/TypeContext.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/TypeContext.java
@@ -7,7 +7,7 @@ public abstract class TypeContext {
 		return new VarBindingContext(var, type, this);
 	}
 	
-	public abstract ValueType lookup(String varName);
+	public abstract ValueType lookupType(String varName);
 	
 	public boolean isPresent(String varName) {
 		if (getNext() == null)

--- a/tools/src/wyvern/target/corewyvernIL/support/TypeGenContext.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/TypeGenContext.java
@@ -30,8 +30,8 @@ public class TypeGenContext extends GenContext {
 	}
 
 	@Override
-	public ValueType lookup(String varName) {
-		return getNext().lookup(varName);
+	public ValueType lookupType(String varName) {
+		return getNext().lookupType(varName);
 	}
 
 	@Override

--- a/tools/src/wyvern/target/corewyvernIL/support/Util.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/Util.java
@@ -8,12 +8,12 @@ import wyvern.target.corewyvernIL.type.StructuralType;
 import wyvern.target.corewyvernIL.type.ValueType;
 
 public class Util {
-	public static ValueType intType() { return theIntType; }
-	public static ValueType unitType() { return theUnitType; }
+	private static ValueType theBooleanType = new NominalType("system","Boolean");
 	private static ValueType theIntType = new NominalType("system","Int");
 	private static ValueType theStringType = new NominalType("system","String");
 	private static ValueType theUnitType = new StructuralType("unitSelf", new LinkedList<DeclType>());
-	public static ValueType stringType() {
-		return theStringType;
-	}
+	public static ValueType booleanType() { return theBooleanType; }
+	public static ValueType intType() { return theIntType; }
+	public static ValueType stringType() { return theStringType; }
+	public static ValueType unitType() { return theUnitType; }
 }

--- a/tools/src/wyvern/target/corewyvernIL/support/VarBindingContext.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/VarBindingContext.java
@@ -14,11 +14,11 @@ public class VarBindingContext extends TypeContext {
 	}
 
 	@Override
-	public ValueType lookup(String varName) {
+	public ValueType lookupType(String varName) {
 		if (varName.equals(this.varName)) {
 			return type;
 		} else {
-			return previous.lookup(varName);
+			return previous.lookupType(varName);
 		}
 	}
 

--- a/tools/src/wyvern/target/corewyvernIL/support/VarEvalContext.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/VarEvalContext.java
@@ -14,11 +14,11 @@ public class VarEvalContext extends EvalContext {
 	}
 
 	@Override
-	public Value lookup(String varName) {
+	public Value lookupValue(String varName) {
 		if (varName.equals(this.varName)) {
 			return v;
 		} else {
-			return previous.lookup(varName);
+			return previous.lookupValue(varName);
 		}
 	}
 
@@ -41,5 +41,10 @@ public class VarEvalContext extends EvalContext {
 	@Override
 	public String endToString() {
 		return varName  + " = " + v + ", " + previous.endToString();
+	}
+
+	@Override
+	protected TypeContext getNext() {
+		return previous;
 	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/support/VarGenContext.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/VarGenContext.java
@@ -26,11 +26,11 @@ public class VarGenContext extends GenContext {
 	}
 	
 	@Override
-	public ValueType lookup(String varName) {
+	public ValueType lookupType(String varName) {
 		if (varName.equals(var))
 			return type;
 		else
-			return getNext().lookup(varName);
+			return getNext().lookupType(varName);
 	}
 	
 	@Override

--- a/tools/src/wyvern/tools/typedAST/core/binding/NameBindingImpl.java
+++ b/tools/src/wyvern/tools/typedAST/core/binding/NameBindingImpl.java
@@ -20,7 +20,7 @@ public class NameBindingImpl extends AbstractBinding implements NameBinding {
 	public Value getValue(EvaluationEnvironment env) {
 		// TODO: code smell, leaving in to make sure I don't need it.  Refactor to move down to ValueBinding and eliminate env parameter
 		throw new RuntimeException("deprecated - to be removed");
-		/*NameBinding bind = env.lookup(getName());
+		/*NameBinding bind = env.lookupValue(getName());
 		assert bind instanceof ValueBinding;
 		return ((ValueBinding)bind).getValue(env);*/
 	}

--- a/tools/src/wyvern/tools/typedAST/core/declarations/ModuleDeclaration.java
+++ b/tools/src/wyvern/tools/typedAST/core/declarations/ModuleDeclaration.java
@@ -330,7 +330,7 @@ public class ModuleDeclaration extends Declaration implements CoreAST {
 		for(Declaration d : reqSeq.getDeclIterator()) {
 			ImportDeclaration req = (ImportDeclaration) d;
 			String name = req.getUri().getSchemeSpecificPart();
-			wyvern.target.corewyvernIL.type.ValueType type = ctx.lookup(name);
+			wyvern.target.corewyvernIL.type.ValueType type = ctx.lookupType(name);
 			types.add(new FormalArg(req.getAsName(), type));
 		}
 		return types;

--- a/tools/src/wyvern/tools/typedAST/core/expressions/Invocation.java
+++ b/tools/src/wyvern/tools/typedAST/core/expressions/Invocation.java
@@ -95,7 +95,7 @@ public class Invocation extends CachingTypedAST implements CoreAST, Assignable {
 			if (w.getName().equals("w")) {
 				System.out.println("Examining w more closely.");
 				System.out.println(((MetadataWrapper) w.getType()).getInner());
-				System.out.println(env.lookup(w.getName()).getType());
+				System.out.println(env.lookupValue(w.getName()).getType());
 			}
 		}
 		*/

--- a/tools/src/wyvern/tools/typedAST/core/expressions/Match.java
+++ b/tools/src/wyvern/tools/typedAST/core/expressions/Match.java
@@ -100,7 +100,7 @@ public class Match extends CachingTypedAST implements CoreAST {
 
 		if (matchingOver instanceof Variable) {
 			Variable w = (Variable) matchingOver;
-			//ClassType wType = (ClassType) env.lookup(w.getName()).getType();
+			//ClassType wType = (ClassType) env.lookupValue(w.getName()).getType();
 			// System.out.println("wType = " + wType);
 			// System.out.println("looked up = " + TaggedInfo.lookupTagByType(wType));
 			// System.out.println("but mot = " + matchingOverTag);
@@ -114,11 +114,11 @@ public class Match extends CachingTypedAST implements CoreAST {
 		System.out.println("v.getType() = " + v.getType());
 		System.out.println("v.getName() = " + v.getName());
 		System.out.println(env);
-		System.out.println(env.lookup(v.getName()));
+		System.out.println(env.lookupValue(v.getName()));
 
 		System.out.println("mo = " + mo + " and its class is " + mo.getClass());
-		System.out.println(env.lookup(v.getName()).getUse());
-		System.out.println(env.lookup(v.getName()).getValue(env));
+		System.out.println(env.lookupValue(v.getName()).getUse());
+		System.out.println(env.lookupValue(v.getName()).getValue(env));
 
 		TypeType ttmo = (TypeType) mo;
 		System.out.println("ttmo.getName() is declared but not actual type = " + ttmo.getName());
@@ -455,7 +455,7 @@ public class Match extends CachingTypedAST implements CoreAST {
 			// System.out.println(tagName);
 
 			//check type exists
-			// TypeBinding type = env.lookupType(tagName.toString()); // FIXME:
+			// TypeBinding type = env.lookupValue(tagName.toString()); // FIXME:
 
 			// if (type == null) {
 			//	ToolError.reportError(ErrorMessage.TYPE_NOT_DECLARED, this, tagName.toString());


### PR DESCRIPTION
This links two classes which are used for different purposes, but are related in structure and content. Adding a getType method to the Value interface allows the type of a variable to be looked up from an EvalContext, so an EvalContext can now be used anywhere a TypeContext is needed.