### PR TITLE
Adding common IDE metadata files to the gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.classpath
+.project
 bin
 .idea
 tools/wyvern-tools.iml


### PR DESCRIPTION
These files are often created by IDEs (namely Eclipse).