### PR TITLE
Refactor interface to expose DefDeclType

### DIFF
--- a/tools/src/wyvern/target/corewyvernIL/support/CallableExprGenerator.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/CallableExprGenerator.java
@@ -2,7 +2,7 @@ package wyvern.target.corewyvernIL.support;
 
 import java.util.List;
 
-import wyvern.target.corewyvernIL.FormalArg;
+import wyvern.target.corewyvernIL.decltype.DefDeclType;
 import wyvern.target.corewyvernIL.expression.Expression;
 import wyvern.tools.errors.HasLocation;
 
@@ -23,6 +23,6 @@ public interface CallableExprGenerator {
 	public Expression genExprWithArgs(List<Expression> args, HasLocation loc);
 	
 	/** Returns null if no argument type is expected */
-	public List<FormalArg> getExpectedArgTypes(TypeContext ctx);
+	public DefDeclType getDeclType(TypeContext ctx);
 
 }

--- a/tools/src/wyvern/target/corewyvernIL/support/DefaultExprGenerator.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/DefaultExprGenerator.java
@@ -2,7 +2,6 @@ package wyvern.target.corewyvernIL.support;
 
 import java.util.List;
 
-import wyvern.target.corewyvernIL.FormalArg;
 import wyvern.target.corewyvernIL.decltype.DefDeclType;
 import wyvern.target.corewyvernIL.expression.Expression;
 import wyvern.target.corewyvernIL.expression.MethodCall;
@@ -29,11 +28,10 @@ public class DefaultExprGenerator implements CallableExprGenerator {
 	}
 
 	@Override
-	public List<FormalArg> getExpectedArgTypes(TypeContext ctx) {
+	public DefDeclType getDeclType(TypeContext ctx) {
 		Expression e = genExpr();
 		ValueType vt = e.typeCheck(ctx);
-		DefDeclType dt = (DefDeclType)vt.findDecl(Util.APPLY_NAME, ctx);
-		return dt.getFormalArgs();
+		return (DefDeclType)vt.findDecl(Util.APPLY_NAME, ctx);
 	}
 
 }

--- a/tools/src/wyvern/target/corewyvernIL/support/InvocationExprGenerator.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/InvocationExprGenerator.java
@@ -52,15 +52,13 @@ public class InvocationExprGenerator implements CallableExprGenerator {
 	}
 
 	@Override
-	public List<FormalArg> getExpectedArgTypes(TypeContext ctx) {
+	public DefDeclType getDeclType(TypeContext ctx) {
 		if (declType instanceof ValDeclType || declType instanceof VarDeclType) {
 			Expression e = genExpr();
 			ValueType vt = e.typeCheck(ctx);
-			DefDeclType dt = (DefDeclType)vt.findDecl(Util.APPLY_NAME, ctx);
-			return dt.getFormalArgs();
+			return (DefDeclType)vt.findDecl(Util.APPLY_NAME, ctx);
 		} else {
-			DefDeclType dt = (DefDeclType) declType;
-			return dt.getFormalArgs();
+			return (DefDeclType) declType;
 		}
 	}
 }

--- a/tools/src/wyvern/tools/typedAST/core/expressions/Application.java
+++ b/tools/src/wyvern/tools/typedAST/core/expressions/Application.java
@@ -17,6 +17,7 @@ import wyvern.stdlib.Globals;
 import wyvern.target.corewyvernIL.FormalArg;
 import wyvern.target.corewyvernIL.decl.TypeDeclaration;
 import wyvern.target.corewyvernIL.decltype.AbstractTypeMember;
+import wyvern.target.corewyvernIL.decltype.DefDeclType;
 import wyvern.target.corewyvernIL.expression.Expression;
 import wyvern.target.corewyvernIL.expression.MethodCall;
 import wyvern.target.corewyvernIL.expression.Variable;
@@ -157,7 +158,8 @@ public class Application extends CachingTypedAST implements CoreAST {
 	@Override
 	public Expression generateIL(GenContext ctx, ValueType expectedType) {
 		CallableExprGenerator exprGen = function.getCallableExpr(ctx);
-		List<FormalArg> formals = exprGen.getExpectedArgTypes(ctx);
+		DefDeclType defdecl = exprGen.getDeclType(ctx);
+        List<FormalArg> formals = defdecl.getFormalArgs();
 
         int offset = 0;
 		// generate arguments		


### PR DESCRIPTION
As per our conversation, I refactored the `CallableExpression` interface to return the `DefDeclType` instead of the `List<FormalArg>`