### PR TITLE
Working logging example in section 2 of Wyvern guide

### DIFF
--- a/tools/src/wyvern/lib/examples/logging/files.wyv
+++ b/tools/src/wyvern/lib/examples/logging/files.wyv
@@ -1,0 +1,13 @@
+/*resource */module files
+
+import java:wyvern.stdlib.support.FileIO.file
+
+type FileWriter
+    def print(x: String): Unit
+
+def openForAppend(path: String): FileWriter
+    val printWriter = file.openForAppend(path)
+    new
+        def print(x: String): Unit
+            printWriter.println(x)
+            printWriter.flush()

--- a/tools/src/wyvern/lib/examples/logging/logApplication.wyv
+++ b/tools/src/wyvern/lib/examples/logging/logApplication.wyv
@@ -1,0 +1,12 @@
+/*resource */module logApplication
+
+import examples.logging.logging
+
+def run(): Unit
+    // Create log file
+    val logFile = logging.makeLog("log.txt")
+
+    // Do something
+
+    // Log status
+    logFile.log("Test log data")

--- a/tools/src/wyvern/lib/examples/logging/logClient.wyv
+++ b/tools/src/wyvern/lib/examples/logging/logClient.wyv
@@ -1,0 +1,3 @@
+import examples.logging.logApplication
+
+logApplication.run()

--- a/tools/src/wyvern/lib/examples/logging/logging.wyv
+++ b/tools/src/wyvern/lib/examples/logging/logging.wyv
@@ -1,0 +1,15 @@
+/*resource */module logging
+
+import wyvern.collections.list
+import examples.logging.files
+
+resource type Log
+    def log(x: String): Unit
+
+def makeLog(path: String): Log
+    val logFile = files.openForAppend(path)
+    val messageList = list.make()
+    new
+        def log(x: String): Unit
+            messageList.append(x)
+            logFile.print(x)

--- a/tools/src/wyvern/stdlib/FileIO.java
+++ b/tools/src/wyvern/stdlib/FileIO.java
@@ -1,0 +1,19 @@
+package wyvern.stdlib.support;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+public class FileIO
+{
+    public static FileIO file = new FileIO();
+
+    public PrintWriter openForAppend(String path) throws IOException
+    {
+        FileWriter fileWriter = new FileWriter(path, true);
+        BufferedWriter bufferedWriter = new BufferedWriter(fileWriter);
+
+        return new PrintWriter(bufferedWriter);
+    }
+}

--- a/tools/src/wyvern/target/corewyvernIL/expression/FieldGet.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/FieldGet.java
@@ -82,4 +82,35 @@ public class FieldGet extends Expression implements Path {
 	public Set<String> getFreeVariables() {
 		return objectExpr.getFreeVariables();
 	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((getName() == null) ? 0 : getName().hashCode());
+		result = prime * result + ((getObjectExpr() == null) ? 0 : getObjectExpr().hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		FieldGet other = (FieldGet) obj;
+		if (getName() == null) {
+			if (other.getName() != null)
+				return false;
+		} else if (!getName().equals(other.getName()))
+			return false;
+		if (getObjectExpr() == null) {
+			if (other.getObjectExpr() != null)
+				return false;
+		} else if (!getObjectExpr().equals(other.getObjectExpr()))
+			return false;
+		return true;
+	}
 }

--- a/tools/src/wyvern/target/corewyvernIL/type/StructuralType.java
+++ b/tools/src/wyvern/target/corewyvernIL/type/StructuralType.java
@@ -140,6 +140,16 @@ public class StructuralType extends ValueType {
 		return null;
 	}
 
+	public List<DeclType> findDecls(String declName, TypeContext ctx) {
+		List<DeclType> mdts = new LinkedList<DeclType>();
+		for (DeclType mdt : getDeclTypes()) {
+			if (mdt.getName().equals(declName)) {
+				mdts.add(mdt);
+			}
+		}
+		return mdts;
+	}
+
 	@Override
 	public ValueType adapt(View v) {
 		List<DeclType> newDTs = new LinkedList<DeclType>();

--- a/tools/src/wyvern/tools/errors/ErrorMessage.java
+++ b/tools/src/wyvern/tools/errors/ErrorMessage.java
@@ -11,6 +11,7 @@ public enum ErrorMessage {
 	TYPE_NOT_DEFINED("Type %ARG is not defined", 1),
 	VARIABLE_NOT_DECLARED("No variable named %ARG is in scope", 1),
 	NO_SUCH_METHOD("There is no visible method named %ARG", 1),
+	NO_METHOD_WITH_THESE_ARG_TYPES("There is no visible method '%ARG'", 1),
 	NOT_A_METHOD("%ARG is not a method", 1),
 	TYPE_NOT_DECLARED("Type %ARG has no declaration in the context", 1),
 	OPERATOR_DOES_NOT_APPLY("Operator %ARG cannot be applied to type %ARG", 2),


### PR DESCRIPTION
Made the logging example in section 2 of the Wyvern guide to work without the use of resource modules. This required modifying typechecking of method calls on Java objects to account for method overloading.