### PR TITLE
Fix FieldSet bug, tests for top-level annotations

### DIFF
--- a/tools/src/wyvern/target/corewyvernIL/expression/FieldSet.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/FieldSet.java
@@ -62,7 +62,10 @@ public class FieldSet extends Expression {
 		// Make sure assigned type is compatible with the field's type.
 		if (!valTypeExpr.isSubtypeOf(valTypeField, ctx))
 			ToolError.reportError(ErrorMessage.ASSIGNMENT_SUBTYPING, this);
-		return Util.unitType();
+		
+		// Return the type of the expression being assigned.
+		return valTypeExpr;
+		
 	}
 
 	@Override
@@ -94,7 +97,8 @@ public class FieldSet extends Expression {
 
 		// Update object's declarations.
 		object.setDecl(varDeclUpdated);
-		return Util.unitValue();
+		return exprInterpreted;
+		
 	}
 
 	@Override

--- a/tools/src/wyvern/tools/tests/ILTests.java
+++ b/tools/src/wyvern/tools/tests/ILTests.java
@@ -1294,6 +1294,7 @@ public class ILTests {
     }
     
     @Test
+    @Category(CurrentlyBroken.class)
     public void testTopLevelAnnotations2() throws ParseException {
     	this.doTestScript("TopLevelAnnotations2.wyv", Util.intType(), new IntegerLiteral(5));
     }

--- a/tools/src/wyvern/tools/tests/ILTests.java
+++ b/tools/src/wyvern/tools/tests/ILTests.java
@@ -1287,4 +1287,15 @@ public class ILTests {
 
         doTest(source, null, new IntegerLiteral(7));
     }
+    
+    @Test
+    public void testTopLevelAnnotations1() throws ParseException {
+    	this.doTestScript("TopLevelAnnotations1.wyv", Util.intType(), new IntegerLiteral(5));
+    }
+    
+    @Test
+    public void testTopLevelAnnotations2() throws ParseException {
+    	this.doTestScript("TopLevelAnnotations2.wyv", Util.intType(), new IntegerLiteral(5));
+    }
+    
 }

--- a/tools/src/wyvern/tools/tests/modules/module/TopLevelAnnotations1.wyv
+++ b/tools/src/wyvern/tools/tests/modules/module/TopLevelAnnotations1.wyv
@@ -1,0 +1,3 @@
+val something : Dyn = 5
+val five : Int = something
+five

--- a/tools/src/wyvern/tools/tests/modules/module/TopLevelAnnotations2.wyv
+++ b/tools/src/wyvern/tools/tests/modules/module/TopLevelAnnotations2.wyv
@@ -1,0 +1,2 @@
+val something : Dyn = 5
+val five : Int = something

--- a/tools/src/wyvern/tools/typedAST/core/declarations/DefDeclaration.java
+++ b/tools/src/wyvern/tools/typedAST/core/declarations/DefDeclaration.java
@@ -378,15 +378,13 @@ public class DefDeclaration extends Declaration implements CoreAST, BoundCode, T
 		valueToAssign = new wyvern.tools.typedAST.core.expressions.Variable(new NameBindingImpl("x", null), null);
 		Assignment setterBody = new Assignment(fieldGet, valueToAssign, null);
 		
-		// The setter takes one argument x : varType; its signature is varType -> Unit
+		// The setter takes one argument x : varType; its signature is varType -> varType
 		LinkedList<NameBinding> setterArgs = new LinkedList<>();
 		setterArgs.add(new NameBindingImpl("x", varType));
-		Type unitType = new UnresolvedType("Unit", receiver.getLocation());
-		//Arrow setterArrType = new Arrow(varType, unitType);
 		
 		// Make and return the declaration.
 		DefDeclaration setterDecl;
-		setterDecl = new DefDeclaration(setterName, unitType, setterArgs, setterBody, false, null);
+		setterDecl = new DefDeclaration(setterName, varType, setterArgs, setterBody, false, null);
 		return setterDecl;
 		
 	}


### PR DESCRIPTION

* FieldSets now type to the expression they contain. For example, if obj has a field called x of type Int and you see the expression obj.x = 5, then this FieldSet will type to Int and return 5 instead of typing to Unit and returning unit. This is consistent with the VM Spec (page 2, rule T-Assign). Accordingly the automatically-generated setters for Var fields in an object have been changed to reflect this.

* Add tests which highlight unusual behaviour with top-level annotations, discussed in issue #86 (but this PR does not include a solution, I'm still working on that).