### PR TITLE
Fixed a bug in the handling of escape sequences

### DIFF
--- a/tools/src/wyvern/tools/errors/ErrorMessage.java
+++ b/tools/src/wyvern/tools/errors/ErrorMessage.java
@@ -88,6 +88,7 @@ public enum ErrorMessage {
 	SCHEME_NOT_RECOGNIZED("import scheme %ARG not recognized; did you forget to \"require java\"?", 1),
 	UNSAFE_JAVA_IMPORT("To import the java package %ARG, make sure you \"require java\" or add the package to the built-in whitelist (experts only)", 1),
 	ILLEGAL_ESCAPE_SEQUENCE("Illegal escape sequence", 0),
+	UNCLOSED_STRING_LITERAL("Unclosed string literal", 0),
 	;
 	
 	private ErrorMessage(String message, int numArgs) {

--- a/tools/src/wyvern/tools/lexing/WyvernLexer.x
+++ b/tools/src/wyvern/tools/lexing/WyvernLexer.x
@@ -224,6 +224,14 @@ import wyvern.tools.errors.ToolError;
         }
 
         if (i < s.length()) {
+            char c = s.charAt(i);
+            if (c == '\\') {
+                ToolError.reportError(ErrorMessage.UNCLOSED_STRING_LITERAL,
+                                      new FileLocation(virtualLocation.getFileName(),
+                                                       virtualLocation.getLine(),
+                                                       virtualLocation.getColumn() + 1));
+            }
+
             new_s.append(s.charAt(i));
         }
 


### PR DESCRIPTION
If the last character is a backslash (e.g. "abc\") which is not a part of an escape sequence, then I wasn't reporting an error.
