### PR TITLE
Reformat OIR classes

### DIFF
--- a/tools/src/wyvern/target/corewyvernIL/astvisitor/EmitOIRState.java
+++ b/tools/src/wyvern/target/corewyvernIL/astvisitor/EmitOIRState.java
@@ -4,11 +4,20 @@ import wyvern.target.corewyvernIL.support.TypeContext;
 import wyvern.target.oir.OIREnvironment;
 
 public class EmitOIRState {
-    public TypeContext cxt;
-    public OIREnvironment env;
+    private TypeContext ctx;
+    private OIREnvironment env;
 
-    public EmitOIRState(TypeContext cxt, OIREnvironment env) {
-        this.cxt = cxt;
+    public EmitOIRState(TypeContext ctx, OIREnvironment env) {
+        this.ctx = ctx;
         this.env = env;
     }
+    
+    public TypeContext getContext() {
+    	return ctx;
+    }
+    
+    public OIREnvironment getEnvironment() {
+    	return env;
+    }
+    
 }


### PR DESCRIPTION
Encapsulate public variables, remove some unused code/comments, putting variable declarations at the place where they get used, other minor stuff like that.

BTW: if possible, could @JonathanAldrich or @RobbieMcKinstry give me a quick rundown on what the OIR classes are? (And also what OIR stands for)