### PR TITLE
Refactor application genIL to reduce complexity

### DIFF
--- a/tools/build.xml
+++ b/tools/build.xml
@@ -122,7 +122,8 @@
                 wyvern/tools/typedAST/core/expressions/Instantiation.java
                 wyvern/tools/typedAST/core/expressions/Invocation.java
                 wyvern/tools/util/TreeWritable.java
-                wyvern/tools/tests/suites/AntRegressionTestSuite.java"
+                wyvern/tools/tests/suites/AntRegressionTestSuite.java
+                wyvern/target/corewyvernIL/support/CallableExprGenerator.java"
             />
         </checkstyle>
     </target>


### PR DESCRIPTION
I wasn't able to directly cherry-pick over the diff from the other branch, but I reproduced the changes manually. Not the cleanest I could make it, but it's an improvement.

Also, the linter is not hooked into `ant build` properly (I think I noticed this when working on the dead code removal) so it doesn't actually enforce that the files remain lint-free. I'll patch this as soon as I get a chance; for a patch to pass tests, I also have to remove all of the lints, so the PR won't be a one-liner.

- R