### PR TITLE
Mangle names of auto-generated getters and setters

### DIFF
--- a/tools/src/wyvern/target/oir/EmitPythonVisitor.java
+++ b/tools/src/wyvern/target/oir/EmitPythonVisitor.java
@@ -229,10 +229,11 @@ public class EmitPythonVisitor extends ASTVisitor<EmitPythonState, String> {
     String objExpr =
       oirFieldSet.getObjectExpr().acceptVisitor(this, state);
     String fieldName = oirFieldSet.getFieldName();
-    String setterName =
-      "set" + fieldName.substring(0, 1).toUpperCase() +
-      fieldName.substring(1);
-
+    
+    // Setting a field: turn this into a method call to the appropriate setter method for that field.
+    String setterName = 
+    		wyvern.tools.typedAST.core.declarations.VarDeclaration.varNameToSetter(fieldName);
+ 
     String strVal;
     if (state.currentMethod.equals(setterName) ||
         state.currentMethod.equals("tco_" + setterName)) {

--- a/tools/src/wyvern/target/oir/EmitPythonVisitor.java
+++ b/tools/src/wyvern/target/oir/EmitPythonVisitor.java
@@ -37,6 +37,7 @@ import wyvern.target.oir.expressions.OIRNew;
 import wyvern.target.oir.expressions.OIRRational;
 import wyvern.target.oir.expressions.OIRString;
 import wyvern.target.oir.expressions.OIRVariable;
+import wyvern.tools.util.GetterAndSetterGeneration;
 
 class EmitPythonState {
     public OIREnvironment oirenv;
@@ -231,8 +232,7 @@ public class EmitPythonVisitor extends ASTVisitor<EmitPythonState, String> {
     String fieldName = oirFieldSet.getFieldName();
     
     // Setting a field: turn this into a method call to the appropriate setter method for that field.
-    String setterName = 
-    		wyvern.tools.typedAST.core.declarations.VarDeclaration.varNameToSetter(fieldName);
+    String setterName = GetterAndSetterGeneration.varNameToSetter(fieldName);
  
     String strVal;
     if (state.currentMethod.equals(setterName) ||

--- a/tools/src/wyvern/tools/tests/OIRTests.java
+++ b/tools/src/wyvern/tools/tests/OIRTests.java
@@ -23,6 +23,7 @@ import wyvern.target.corewyvernIL.astvisitor.EmitOIRState;
 import wyvern.target.corewyvernIL.astvisitor.TailCallVisitor;
 import wyvern.target.corewyvernIL.expression.Expression;
 import wyvern.target.corewyvernIL.expression.IExpr;
+import wyvern.target.corewyvernIL.expression.Value;
 import wyvern.target.corewyvernIL.modules.TypedModuleSpec;
 import wyvern.target.corewyvernIL.support.EvalContext;
 import wyvern.target.corewyvernIL.support.GenContext;
@@ -61,8 +62,11 @@ public class OIRTests {
     GenContext pythonGenContext = Globals.getGenContext(new InterpreterState(InterpreterState.PLATFORM_PYTHON,
                                                                              new File(TestUtil.BASE_PATH),
                                                                              new File(TestUtil.LIB_PATH)));
+    
+    // Generate IL and perform tail-call optimisations.
     IExpr ILprogram = ast.generateIL(pythonGenContext, null, new LinkedList<TypedModuleSpec>());
     TailCallVisitor.annotate(ILprogram);
+    
     if (debug) {
       System.out.println("Wyvern Program:");
       System.out.println(input);

--- a/tools/src/wyvern/tools/typedAST/core/declarations/DefDeclaration.java
+++ b/tools/src/wyvern/tools/typedAST/core/declarations/DefDeclaration.java
@@ -47,6 +47,7 @@ import wyvern.tools.types.extensions.Arrow;
 import wyvern.tools.types.extensions.Tuple;
 import wyvern.tools.types.extensions.Unit;
 import wyvern.tools.util.EvaluationEnvironment;
+import wyvern.tools.util.GetterAndSetterGeneration;
 import wyvern.tools.util.TreeWritable;
 import wyvern.tools.util.TreeWriter;
 
@@ -326,7 +327,7 @@ public class DefDeclaration extends Declaration implements CoreAST, BoundCode, T
 											  String varName, Type varType) {
 		
 		// The body of the getter is an invocation of the form: receiver.varName
-		String getterName = VarDeclaration.varNameToGetter(varName);
+		String getterName = GetterAndSetterGeneration.varNameToGetter(varName);
 		Invocation getterBody = new Invocation(receiver, varName, null, null);
 		
 		// Make and return the declaration.
@@ -349,7 +350,7 @@ public class DefDeclaration extends Declaration implements CoreAST, BoundCode, T
 											  String varName, Type varType) {
 
 		// The body of the setter is an assignment of the form: receiver.varName = x
-		String setterName = VarDeclaration.varNameToSetter(varName);
+		String setterName = GetterAndSetterGeneration.varNameToSetter(varName);
 		Invocation fieldGet = new Invocation(receiver, varName, null, null);
 		wyvern.tools.typedAST.core.expressions.Variable valueToAssign;
 		valueToAssign = new wyvern.tools.typedAST.core.expressions.Variable(new NameBindingImpl("x", null), null);

--- a/tools/src/wyvern/tools/typedAST/core/declarations/VarDeclaration.java
+++ b/tools/src/wyvern/tools/typedAST/core/declarations/VarDeclaration.java
@@ -244,11 +244,11 @@ public class VarDeclaration extends Declaration implements CoreAST {
 	}
 	
 	public static String varNameToSetter (String s) {
-		return "__set" + Character.toUpperCase(s.charAt(0)) + s.substring(1);		
+		return "__set" + Character.toUpperCase(s.charAt(0)) + s.substring(1);
 	}
 
 	public static String getterToVarName (String s) {
-		return s.replaceFirst("get", "");
+		return s.replaceFirst("__get", "");
 	}
 	
 	@Override

--- a/tools/src/wyvern/tools/typedAST/core/declarations/VarDeclaration.java
+++ b/tools/src/wyvern/tools/typedAST/core/declarations/VarDeclaration.java
@@ -36,6 +36,7 @@ import wyvern.tools.types.Environment;
 import wyvern.tools.types.Type;
 import wyvern.tools.types.TypeResolver;
 import wyvern.tools.util.EvaluationEnvironment;
+import wyvern.tools.util.GetterAndSetterGeneration;
 import wyvern.tools.util.TreeWriter;
 
 import java.util.LinkedList;
@@ -188,7 +189,7 @@ public class VarDeclaration extends Declaration implements CoreAST {
 		VarDeclaration varDecl = new VarDeclaration(varName, this.binding.getType(), this.definition, location);
 		DeclSequence tempObjBody = new DeclSequence(varDecl);
 		New tempObj = new New(tempObjBody, location);
-		String tempObjName = varNameToTempObj(varName);
+		String tempObjName = GetterAndSetterGeneration.varNameToTempObj(varName);
 		ValDeclaration letDecl = new ValDeclaration(tempObjName, tempObj, null);
 		
 		// Update context.
@@ -234,23 +235,7 @@ public class VarDeclaration extends Declaration implements CoreAST {
 		ctx = ctx.extend(varName, methodCallExpr, varValueType);
 		tlc.updateContext(ctx);
 	}
-	
-	public static String varNameToTempObj (String s) {
-		return "_temp" + Character.toUpperCase(s.charAt(0)) + s.substring(1);
-	}
-	
-	public static String varNameToGetter (String s) {
-		return "_get" + Character.toUpperCase(s.charAt(0)) + s.substring(1);
-	}
-	
-	public static String varNameToSetter (String s) {
-		return "_set" + Character.toUpperCase(s.charAt(0)) + s.substring(1);
-	}
 
-	public static String getterToVarName (String s) {
-		return s.replaceFirst("_get", "");
-	}
-	
 	@Override
 	public void addModuleDecl(TopLevelContext tlc) {
 		// do nothing--adding module declarations handled by genTopLevel method above.

--- a/tools/src/wyvern/tools/typedAST/core/declarations/VarDeclaration.java
+++ b/tools/src/wyvern/tools/typedAST/core/declarations/VarDeclaration.java
@@ -240,11 +240,11 @@ public class VarDeclaration extends Declaration implements CoreAST {
 	}
 	
 	public static String varNameToGetter (String s) {
-		return "get" + Character.toUpperCase(s.charAt(0)) + s.substring(1);
+		return "__get" + Character.toUpperCase(s.charAt(0)) + s.substring(1);
 	}
 	
 	public static String varNameToSetter (String s) {
-		return "set" + Character.toUpperCase(s.charAt(0)) + s.substring(1);		
+		return "__set" + Character.toUpperCase(s.charAt(0)) + s.substring(1);		
 	}
 
 	public static String getterToVarName (String s) {

--- a/tools/src/wyvern/tools/typedAST/core/declarations/VarDeclaration.java
+++ b/tools/src/wyvern/tools/typedAST/core/declarations/VarDeclaration.java
@@ -236,19 +236,19 @@ public class VarDeclaration extends Declaration implements CoreAST {
 	}
 	
 	public static String varNameToTempObj (String s) {
-		return "__temp" + Character.toUpperCase(s.charAt(0)) + s.substring(1);
+		return "_temp" + Character.toUpperCase(s.charAt(0)) + s.substring(1);
 	}
 	
 	public static String varNameToGetter (String s) {
-		return "__get" + Character.toUpperCase(s.charAt(0)) + s.substring(1);
+		return "_get" + Character.toUpperCase(s.charAt(0)) + s.substring(1);
 	}
 	
 	public static String varNameToSetter (String s) {
-		return "__set" + Character.toUpperCase(s.charAt(0)) + s.substring(1);
+		return "_set" + Character.toUpperCase(s.charAt(0)) + s.substring(1);
 	}
 
 	public static String getterToVarName (String s) {
-		return s.replaceFirst("__get", "");
+		return s.replaceFirst("_get", "");
 	}
 	
 	@Override

--- a/tools/src/wyvern/tools/typedAST/core/expressions/Assignment.java
+++ b/tools/src/wyvern/tools/typedAST/core/expressions/Assignment.java
@@ -20,7 +20,6 @@ import wyvern.tools.errors.FileLocation;
 import wyvern.tools.errors.ToolError;
 import static wyvern.tools.errors.ToolError.reportEvalError;
 import wyvern.tools.typedAST.abs.CachingTypedAST;
-import wyvern.tools.typedAST.core.declarations.VarDeclaration;
 import wyvern.tools.typedAST.interfaces.Assignable;
 import wyvern.tools.typedAST.interfaces.CoreAST;
 import wyvern.tools.typedAST.interfaces.ExpressionAST;
@@ -30,6 +29,7 @@ import wyvern.tools.types.Environment;
 import wyvern.tools.types.Type;
 import wyvern.tools.types.extensions.Unit;
 import wyvern.tools.util.EvaluationEnvironment;
+import wyvern.tools.util.GetterAndSetterGeneration;
 
 public class Assignment extends CachingTypedAST implements CoreAST {
 
@@ -134,8 +134,8 @@ public class Assignment extends CachingTypedAST implements CoreAST {
             // Figure out the var being assigned and get the name of its setter.
             MethodCall methCall = (MethodCall) exprFieldGet;
             String methName     = methCall.getMethodName();
-            String varName      = VarDeclaration.getterToVarName(methName);
-            String setterName   = VarDeclaration.varNameToSetter(varName);
+            String varName      = GetterAndSetterGeneration.getterToVarName(methName);
+            String setterName   = GetterAndSetterGeneration.varNameToSetter(varName);
             
             // Return an invocation to the setter w/ appropriate argmuents supplied.
             IExpr receiver = methCall.getObjectExpr();

--- a/tools/src/wyvern/tools/util/GetterAndSetterGeneration.java
+++ b/tools/src/wyvern/tools/util/GetterAndSetterGeneration.java
@@ -1,0 +1,39 @@
+package wyvern.tools.util;
+
+/**
+ * During IL generation, getter and setter methods are automatically generated for mutable fields.
+ * This class provides a uniform description of how the names of those methods relate to the name
+ * of the mutable variable.
+ */
+public class GetterAndSetterGeneration {
+
+	/**
+	 * From the name of a mutable variable, return the "this" name of the object containing the
+	 * mutable field and the getter/setter methods operating on that mutable field. 
+	 */
+	public static String varNameToTempObj (String s) {
+		return "_temp" + Character.toUpperCase(s.charAt(0)) + s.substring(1);
+	}
+	
+	/**
+	 * From the name of a mutable variable, return the name of its getter method.
+	 */
+	public static String varNameToGetter (String s) {
+		return "_get" + Character.toUpperCase(s.charAt(0)) + s.substring(1);
+	}
+
+	/**
+	 * From the name of a mutable variable, return the name of its setter method.
+	 */
+	public static String varNameToSetter (String s) {
+		return "_set" + Character.toUpperCase(s.charAt(0)) + s.substring(1);
+	}
+
+	/**
+	 * From the name of a getter method, return the name of the variable it is accessing.
+	 */
+	public static String getterToVarName (String s) {
+		return s.replaceFirst("_get", "");
+	}
+	
+}


### PR DESCRIPTION
Addresses #138

Suppose you have an object with a var field like this:

```
val obj = new
  var x : Int = 0
```

When generating Wyvern IL code this is turned into the following object:

```
val obj = new
   var x: Int = 0

   def setX(y: Int): Unit =
      this.x = y

   def getX(): Int =
      this.x
```

When you access a field ala obj.x this is actually turned into obj.getX(). obj.x = y gets turned into obj.setX(y). (Discussion of why this approach is done can be found in #64)

#138 highlights an issue with the auto-generated method names, which is that if an object has a mutable field called x and a user-defined setX, then the auto-generated setX will clash with that. This causes the ToolError in #138.

My P.R. doesn't give a robust solution to the problem. It just mangles the names of the auto-generated getters/setters a bit (__getX instead of getX) to minimise these problems.