### PR TITLE
Typechecking dynamic objects

### DIFF
--- a/tools/src/wyvern/target/corewyvernIL/expression/FieldGet.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/FieldGet.java
@@ -12,6 +12,7 @@ import wyvern.target.corewyvernIL.decltype.ValDeclType;
 import wyvern.target.corewyvernIL.decltype.VarDeclType;
 import wyvern.target.corewyvernIL.support.EvalContext;
 import wyvern.target.corewyvernIL.support.TypeContext;
+import wyvern.target.corewyvernIL.support.Util;
 import wyvern.target.corewyvernIL.support.View;
 import wyvern.target.corewyvernIL.type.ValueType;
 import wyvern.target.oir.OIREnvironment;
@@ -47,6 +48,7 @@ public class FieldGet extends Expression implements Path {
 	@Override
 	public ValueType typeCheck(TypeContext ctx) {
 		ValueType vt = objectExpr.typeCheck(ctx);
+		if (Util.isDynamicType(vt)) return Util.dynType();
 		DeclType dt = vt.findDecl(fieldName, ctx);
 		if (dt == null)
 			ToolError.reportError(ErrorMessage.NO_SUCH_FIELD, this, fieldName);

--- a/tools/src/wyvern/target/corewyvernIL/expression/FieldSet.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/FieldSet.java
@@ -61,7 +61,11 @@ public class FieldSet extends Expression {
 	@Override
 	public ValueType typeCheck(TypeContext ctx) {
 
-		if (settingDynamicObject(ctx)) return Util.dynType();
+	    // Setting the field of a dynamic object.
+		if (settingDynamicObject(ctx)) {
+		    exprToAssign.typeCheck(ctx);
+		    return Util.dynType();
+		}
 		
 		// Figure out types of object and expression.
 		StructuralType varTypeStructural = objectExpr.typeCheck(ctx).getStructuralType(ctx);

--- a/tools/src/wyvern/target/corewyvernIL/expression/MethodCall.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/MethodCall.java
@@ -77,7 +77,13 @@ public class MethodCall extends Expression {
 
 	@Override
 	public ValueType typeCheck(TypeContext ctx) {
-		if (Util.isDynamicType(getReceiverType(ctx))) return Util.dynType();
+	    // If calling on a dynamic receiver, it types to Dyn (provided the args typecheck)
+		if (Util.isDynamicType(getReceiverType(ctx))) {
+		    for (IExpr arg : args) {
+		        arg.typeCheck(ctx);
+		    }
+		    return Util.dynType();
+		}
 		typeMethodDeclaration(ctx);
 		return getExprType();
 	}

--- a/tools/src/wyvern/target/corewyvernIL/expression/MethodCall.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/MethodCall.java
@@ -12,6 +12,7 @@ import wyvern.target.corewyvernIL.decltype.DeclType;
 import wyvern.target.corewyvernIL.decltype.DefDeclType;
 import wyvern.target.corewyvernIL.support.EvalContext;
 import wyvern.target.corewyvernIL.support.TypeContext;
+import wyvern.target.corewyvernIL.support.Util;
 import wyvern.target.corewyvernIL.support.View;
 import wyvern.target.corewyvernIL.support.ViewExtension;
 import wyvern.target.corewyvernIL.type.StructuralType;
@@ -25,13 +26,14 @@ public class MethodCall extends Expression {
 	private IExpr objectExpr;
 	private String methodName;
 	private List<? extends IExpr> args;
+	private ValueType receiverType;
 
-	public MethodCall(IExpr e, String methodName,
+	public MethodCall(IExpr receiverExpr, String methodName,
 			List<? extends IExpr> args2, HasLocation location) {
 		super(location != null ? location.getLocation():null);
 		//if (getLocation() == null || getLocation().line == -1)
 		//	throw new RuntimeException("missing location");
-		this.objectExpr = e;
+		this.objectExpr = receiverExpr;
 		this.methodName = methodName;
 		this.args = args2;
 		// sanity check
@@ -65,9 +67,17 @@ public class MethodCall extends Expression {
 	public List<? extends IExpr> getArgs() {
 		return args;
 	}
+	
+	private ValueType getReceiverType(TypeContext ctx) {
+		if (receiverType == null) {
+			receiverType = objectExpr.typeCheck(ctx);
+		}
+		return receiverType;
+	}
 
 	@Override
 	public ValueType typeCheck(TypeContext ctx) {
+		if (Util.isDynamicType(getReceiverType(ctx))) return Util.dynType();
 		typeMethodDeclaration(ctx);
 		return getExprType();
 	}
@@ -113,7 +123,7 @@ public class MethodCall extends Expression {
 	public DefDeclType typeMethodDeclaration(TypeContext ctx) {
 
 		// Typecheck receiver.
-		ValueType receiver = objectExpr.typeCheck(ctx);
+		ValueType receiver = getReceiverType(ctx);
 		StructuralType receiverType = receiver.getStructuralType(ctx);
 
 		// Sanity check: make sure it has declarations.

--- a/tools/src/wyvern/target/corewyvernIL/support/DefaultExprGenerator.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/DefaultExprGenerator.java
@@ -32,7 +32,8 @@ public class DefaultExprGenerator implements CallableExprGenerator {
 	public DefDeclType getDeclType(TypeContext ctx) {
 		IExpr e = genExpr();
 		ValueType vt = e.typeCheck(ctx);
-		return (DefDeclType)vt.findDecl(Util.APPLY_NAME, ctx).adapt(View.from(expr, ctx));
+		return (DefDeclType) vt.findDecl(Util.APPLY_NAME, ctx);
+		// return (DefDeclType)vt.findDecl(Util.APPLY_NAME, ctx).adapt(View.from(expr, ctx));
 	}
 
 }

--- a/tools/src/wyvern/target/corewyvernIL/support/InvocationExprGenerator.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/InvocationExprGenerator.java
@@ -25,16 +25,24 @@ public class InvocationExprGenerator implements CallableExprGenerator {
 	private final FileLocation location;
 	
 	public InvocationExprGenerator(IExpr iExpr, String operationName, GenContext ctx, FileLocation loc) {
+		
 		this.receiver = iExpr;
-		ValueType rt = iExpr.typeCheck(ctx);
-		List<DeclType> dts = rt.findDecls(operationName, ctx);
-		location = loc;
+		this.location = loc;
+	
+		ValueType receiverType = iExpr.typeCheck(ctx);
+		
+		if (Util.isDynamicType(receiverType)) {
+			this.declType = null;
+			return;
+		}
+		
+		List<DeclType> dts = receiverType.findDecls(operationName, ctx);
 		// not interested in finding Type Decls (abstract or not)
 		dts.removeIf(cdt -> cdt.isTypeDecl());
 		if (dts.size() == 0)
 			ToolError.reportError(ErrorMessage.NO_SUCH_METHOD, loc, operationName);
 		if (dts.size() >1)
-			ToolError.reportError(ErrorMessage.DUPLICATE_MEMBER, loc, rt.toString(), operationName);
+			ToolError.reportError(ErrorMessage.DUPLICATE_MEMBER, loc, receiverType.toString(), operationName);
 		DeclType dt = dts.get(0);
 		declType = dt.adapt(View.from(iExpr, ctx));
 	}
@@ -62,10 +70,14 @@ public class InvocationExprGenerator implements CallableExprGenerator {
 
 	@Override
 	public DefDeclType getDeclType(TypeContext ctx) {
-		if (declType instanceof ValDeclType || declType instanceof VarDeclType) {
+		
+		if (declType == null) {
+			return null;
+		} else if (declType instanceof ValDeclType || declType instanceof VarDeclType) {
 			Expression e = genExpr();
 			ValueType vt = e.typeCheck(ctx);
-			return (DefDeclType)vt.findDecl(Util.APPLY_NAME, ctx).adapt(View.from(receiver, ctx));
+			return (DefDeclType)vt.findDecl(Util.APPLY_NAME, ctx);
+			// return (DefDeclType)vt.findDecl(Util.APPLY_NAME, ctx).adapt(View.from(receiver, ctx));
 		} else if (declType instanceof DefDeclType) {
 			return (DefDeclType) declType;
 		} else {

--- a/tools/src/wyvern/target/corewyvernIL/support/InvocationExprGenerator.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/InvocationExprGenerator.java
@@ -69,6 +69,9 @@ public class InvocationExprGenerator implements CallableExprGenerator {
 	}
 
 	@Override
+	/**
+	 * 
+	 */
 	public DefDeclType getDeclType(TypeContext ctx) {
 		
 		if (declType == null) {

--- a/tools/src/wyvern/target/corewyvernIL/support/Util.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/Util.java
@@ -44,4 +44,10 @@ public class Util {
 		return new ObjectValue(new LinkedList<Declaration>(), "unitSelf", theUnitType, null, null, EvalContext.empty());
 	}
 	public static final String APPLY_NAME = "apply";
+	
+	public static boolean isDynamicType(ValueType type) {
+		return type.equals(new NominalType("system", "Dyn"))
+				|| type instanceof DynamicType;
+	}
+	
 }

--- a/tools/src/wyvern/target/corewyvernIL/transformers/DynCastsTransformer.java
+++ b/tools/src/wyvern/target/corewyvernIL/transformers/DynCastsTransformer.java
@@ -35,6 +35,7 @@ import wyvern.target.corewyvernIL.expression.RationalLiteral;
 import wyvern.target.corewyvernIL.expression.StringLiteral;
 import wyvern.target.corewyvernIL.expression.Variable;
 import wyvern.target.corewyvernIL.support.GenContext;
+import wyvern.target.corewyvernIL.support.Util;
 import wyvern.target.corewyvernIL.type.CaseType;
 import wyvern.target.corewyvernIL.type.DataType;
 import wyvern.target.corewyvernIL.type.DynamicType;
@@ -55,9 +56,7 @@ public class DynCastsTransformer extends ASTVisitor<GenContext, ASTNode> {
 	 * @param ctx: context in which typechecking happens.
 	 */
 	private boolean hasDynamicType(IExpr expr, GenContext ctx) {
-		ValueType type = expr.typeCheck(ctx);
-		return type.equals(new NominalType("system", "Dyn"))
-				|| type instanceof DynamicType;
+		return Util.isDynamicType(expr.typeCheck(ctx));
 	}
 	
 	/**

--- a/tools/src/wyvern/tools/tests/ILTests.java
+++ b/tools/src/wyvern/tools/tests/ILTests.java
@@ -1334,4 +1334,30 @@ public class ILTests {
     	doTest(src, Util.intType(), new IntegerLiteral(5));
     }
     
+    @Test
+    public void testDynamicObjects() throws ParseException {
+    	
+    	String src = "val obj : Dyn = new\n"
+    			   + "    def method(): Int = 5\n"
+    			   + "obj.method()";
+    	doTest(src, Util.dynType(), new IntegerLiteral(5));
+    	
+    }
+    
+    @Test
+    public void testDynamicObjects2() throws ParseException {
+    	String src = "val obj: Dyn = new\n"
+    			   + "    val field: Int = 5\n"
+    			   + "obj.field";
+    	doTest(src, Util.dynType(), new IntegerLiteral(5));
+    }
+    
+    @Test
+    public void testDynamicObjects3() throws ParseException {
+    	String src = "val obj: Dyn = new\n"
+    			   + "    var field: Int = 5\n"
+    			   + "obj.field";
+    	doTest(src, Util.dynType(), new IntegerLiteral(5));
+    }
+    
 }

--- a/tools/src/wyvern/tools/tests/ILTests.java
+++ b/tools/src/wyvern/tools/tests/ILTests.java
@@ -1361,13 +1361,12 @@ public class ILTests {
     }
     
     @Test
-    @Category(CurrentlyBroken.class)
     public void testDynamicObjectVarFieldWithUpdate() throws ParseException {
     	String src = "val obj: Dyn = new\n"
     			   + "    var field: Int = 5\n"
     			   + "obj.field = 10\n"
     			   + "obj.field";
-    	doTest(src, Util.intType(), new IntegerLiteral(10));
+    	doTest(src, Util.dynType(), new IntegerLiteral(10));
     }
     
     @Test

--- a/tools/src/wyvern/tools/tests/ILTests.java
+++ b/tools/src/wyvern/tools/tests/ILTests.java
@@ -1335,7 +1335,7 @@ public class ILTests {
     }
     
     @Test
-    public void testDynamicObjects() throws ParseException {
+    public void testDynamicObjectMethods() throws ParseException {
     	
     	String src = "val obj : Dyn = new\n"
     			   + "    def method(): Int = 5\n"
@@ -1345,7 +1345,7 @@ public class ILTests {
     }
     
     @Test
-    public void testDynamicObjects2() throws ParseException {
+    public void testDynamicObjectValField() throws ParseException {
     	String src = "val obj: Dyn = new\n"
     			   + "    val field: Int = 5\n"
     			   + "obj.field";
@@ -1353,10 +1353,28 @@ public class ILTests {
     }
     
     @Test
-    public void testDynamicObjects3() throws ParseException {
+    public void testDynamicObjectVarField() throws ParseException {
     	String src = "val obj: Dyn = new\n"
     			   + "    var field: Int = 5\n"
     			   + "obj.field";
+    	doTest(src, Util.dynType(), new IntegerLiteral(5));
+    }
+    
+    @Test
+    @Category(CurrentlyBroken.class)
+    public void testDynamicObjectVarFieldWithUpdate() throws ParseException {
+    	String src = "val obj: Dyn = new\n"
+    			   + "    var field: Int = 5\n"
+    			   + "obj.field = 10\n"
+    			   + "obj.field";
+    	doTest(src, Util.intType(), new IntegerLiteral(10));
+    }
+    
+    @Test
+    public void testDynamicObjectMethodWithArgs() throws ParseException {
+    	String src = "val obj: Dyn = new\n"
+    			   + "    def method(x: Int): Int = x\n"
+    			   + "obj.method(5)";
     	doTest(src, Util.dynType(), new IntegerLiteral(5));
     }
     

--- a/tools/src/wyvern/tools/typedAST/core/expressions/Application.java
+++ b/tools/src/wyvern/tools/typedAST/core/expressions/Application.java
@@ -159,7 +159,7 @@ public class Application extends CachingTypedAST implements CoreAST {
         	
         	// Need to do this to find out what the method name is.
         	if (!(function instanceof Invocation))
-        		ToolError.reportError(ErrorMessage.EXPECTED_RECORD_TYPE, this);
+        		throw new RuntimeException("Getting field of dynamic object, but dynamic object isn't an invocation.");
         	Invocation invocation = (Invocation) function;
         	
         	return new MethodCall(

--- a/tools/src/wyvern/tools/typedAST/core/expressions/Application.java
+++ b/tools/src/wyvern/tools/typedAST/core/expressions/Application.java
@@ -145,6 +145,7 @@ public class Application extends CachingTypedAST implements CoreAST {
             List<TypedModuleSpec> dependencies) {
 
         CallableExprGenerator exprGen = function.getCallableExpr(ctx);
+        
         DefDeclType ddt = exprGen.getDeclType(ctx);
         List<FormalArg> formals = ddt.getFormalArgs();
 

--- a/tools/src/wyvern/tools/typedAST/core/expressions/Application.java
+++ b/tools/src/wyvern/tools/typedAST/core/expressions/Application.java
@@ -21,7 +21,6 @@ import wyvern.target.corewyvernIL.expression.New;
 import wyvern.target.corewyvernIL.modules.TypedModuleSpec;
 import wyvern.target.corewyvernIL.support.CallableExprGenerator;
 import wyvern.target.corewyvernIL.support.GenContext;
-import wyvern.target.corewyvernIL.support.Util;
 import wyvern.target.corewyvernIL.type.StructuralType;
 import wyvern.target.corewyvernIL.type.ValueType;
 import wyvern.tools.errors.ErrorMessage;
@@ -151,22 +150,25 @@ public class Application extends CachingTypedAST implements CoreAST {
         /* Method call on a dynamic object. We pretend there's an appropriate declaration,
          * and ignore the expression generator. */
         if (exprGen.getDeclType(ctx) == null) {
-        	
-        	// Generate code for the arguments.
-        	List<IExpr> args = new LinkedList<>();
-        	if (!(argument instanceof UnitVal))
-        		args.add(argument.generateIL(ctx, null, dependencies));
-        	
-        	// Need to do this to find out what the method name is.
-        	if (!(function instanceof Invocation))
-        		throw new RuntimeException("Getting field of dynamic object, but dynamic object isn't an invocation.");
-        	Invocation invocation = (Invocation) function;
-        	
-        	return new MethodCall(
-        		invocation.getReceiver().generateIL(ctx, null, dependencies),
-        		invocation.getOperationName(),
-        		args,
-        		this);
+
+            // Generate code for the arguments.
+            List<IExpr> args = new LinkedList<>();
+            if (!(argument instanceof UnitVal)) {
+                args.add(argument.generateIL(ctx, null, dependencies));
+            }
+    
+            // Need to do this to find out what the method name is.
+            if (!(function instanceof Invocation)) {
+                throw new RuntimeException("Getting field of dynamic object,"
+                                          + "which isn't an invocation.");
+            }
+            Invocation invocation = (Invocation) function;
+
+            return new MethodCall(
+                invocation.getReceiver().generateIL(ctx, null, dependencies),
+                invocation.getOperationName(),
+                args,
+                this);
         }
         
         /* Otherwise look up declaration. Ensure arguments match the declaration. */

--- a/tools/src/wyvern/tools/typedAST/core/expressions/Assignment.java
+++ b/tools/src/wyvern/tools/typedAST/core/expressions/Assignment.java
@@ -13,7 +13,6 @@ import wyvern.target.corewyvernIL.expression.MethodCall;
 import wyvern.target.corewyvernIL.modules.TypedModuleSpec;
 import wyvern.target.corewyvernIL.support.CallableExprGenerator;
 import wyvern.target.corewyvernIL.support.GenContext;
-import wyvern.target.corewyvernIL.support.Util;
 import wyvern.target.corewyvernIL.type.ValueType;
 import wyvern.tools.errors.ErrorMessage;
 import static wyvern.tools.errors.ErrorMessage.VALUE_CANNOT_BE_APPLIED;
@@ -114,26 +113,26 @@ public class Assignment extends CachingTypedAST implements CoreAST {
 
     private IExpr generateFieldGet(GenContext ctx, List<TypedModuleSpec> dependencies) {
     
-    	// In most cases we can get a generator to do this for us.
-    	CallableExprGenerator cegReceiver = target.getCallableExpr(ctx);
-    	if (cegReceiver.getDeclType(ctx) != null)
-    		return cegReceiver.genExpr();
-    	
-    	// If the receiver is dynamic (signified by getDeclType being null), we have to manually do this.
-    	
-    	if (target instanceof Invocation) {
-        	Invocation invocation = (Invocation) target;
-        	return new FieldGet(
-        			invocation.getReceiver().generateIL(ctx, null, dependencies),
-        			invocation.getOperationName(),
-        			getLocation());
-    	}
-    	else if (target instanceof Variable) {
-    		return ctx.lookupExp(((Variable)target).getName(), getLocation());
-    	}
-    	else {
-    		throw new RuntimeException("Getting field of dynamic object, but dynamic object's AST is some unsupported type: " + target.getClass());
-    	}
+        // In most cases we can get a generator to do this for us.
+        CallableExprGenerator cegReceiver = target.getCallableExpr(ctx);
+        if (cegReceiver.getDeclType(ctx) != null) {
+            return cegReceiver.genExpr();
+        }
+
+        // If the receiver is dynamic (signified by getDeclType being null),
+        // we have to manually do this.
+        if (target instanceof Invocation) {
+            Invocation invocation = (Invocation) target;
+            return new FieldGet(
+                    invocation.getReceiver().generateIL(ctx, null, dependencies),
+                    invocation.getOperationName(),
+                    getLocation());
+        } else if (target instanceof Variable) {
+            return ctx.lookupExp(((Variable)target).getName(), getLocation());
+        } else {
+            throw new RuntimeException("Getting field of dynamic object,"
+                    + "but dynamic object's AST is some unsupported type: " + target.getClass());
+        }
     }
     
     @Override

--- a/tools/src/wyvern/tools/typedAST/core/expressions/Invocation.java
+++ b/tools/src/wyvern/tools/typedAST/core/expressions/Invocation.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import wyvern.stdlib.Globals;
+import wyvern.target.corewyvernIL.expression.FieldGet;
 import wyvern.target.corewyvernIL.expression.IExpr;
 import wyvern.target.corewyvernIL.modules.TypedModuleSpec;
 import wyvern.target.corewyvernIL.support.CallableExprGenerator;
@@ -165,7 +166,15 @@ public class Invocation extends CachingTypedAST implements CoreAST, Assignable {
             List<TypedModuleSpec> dependencies) {
 
         CallableExprGenerator generator = getCallableExpr(ctx);
-
+        
+        // Invoking property of a dynamic object; don't bother validating things.
+        if (generator.getDeclType(ctx) == null) {
+        	return new FieldGet(
+        		receiver.generateIL(ctx, null, null),
+        		operationName,
+        		location);
+        }
+        
         if (argument != null) {
             IExpr arg  = ((ExpressionAST) argument)
                 .generateIL(ctx, null, dependencies);

--- a/tools/src/wyvern/tools/typedAST/core/expressions/Invocation.java
+++ b/tools/src/wyvern/tools/typedAST/core/expressions/Invocation.java
@@ -168,10 +168,10 @@ public class Invocation extends CachingTypedAST implements CoreAST, Assignable {
         
         // Invoking property of a dynamic object; don't bother validating things.
         if (generator.getDeclType(ctx) == null) {
-        	return new FieldGet(
-        		receiver.generateIL(ctx, null, null),
-        		operationName,
-        		location);
+            return new FieldGet(
+                receiver.generateIL(ctx, null, null),
+                operationName,
+                location);
         }
         
         if (argument != null) {

--- a/tools/src/wyvern/tools/typedAST/core/expressions/Invocation.java
+++ b/tools/src/wyvern/tools/typedAST/core/expressions/Invocation.java
@@ -39,7 +39,7 @@ public class Invocation extends CachingTypedAST implements CoreAST, Assignable {
 
     private String operationName;
     private ExpressionAST receiver;
-    private TypedAST argument;
+    private ExpressionAST argument;
     private FileLocation location = FileLocation.UNKNOWN;
 
     /**
@@ -52,8 +52,7 @@ public class Invocation extends CachingTypedAST implements CoreAST, Assignable {
       */
     public Invocation(TypedAST op1, String operatorName, TypedAST op2, FileLocation fileLocation) {
         this.receiver = (ExpressionAST) op1;
-
-        this.argument = op2;
+        this.argument = (ExpressionAST) op2;
         this.operationName = operatorName;
         this.location = fileLocation;
     }
@@ -84,7 +83,7 @@ public class Invocation extends CachingTypedAST implements CoreAST, Assignable {
         return argument;
     }
 
-    public TypedAST getReceiver() {
+    public ExpressionAST getReceiver() {
         return receiver;
     }
 


### PR DESCRIPTION
This P.R. extends the typechecker to permit var/val/method accesses on a dynamic object and adds a bunch of tests to demonstrate that this works.

For example this code:

```
val obj: Dyn = new
    val field: Int = 5
obj.field
```

The way it's done is by using a sentinel value of null for InvocationExprGenerator.declType. Unfortunately this means any user of InvocationExprGenerator needs to manually check whether getDeclType returns null.