### PR TITLE
Updated modules' syntax

### DIFF
--- a/stdlib/db/safeSQL.wyv
+++ b/stdlib/db/safeSQL.wyv
@@ -1,6 +1,4 @@
-resource module safeSQL
-
-require db.StringSQL as stringSQL
+module def safeSQL(stringSQL : db.StringSQL)
 
 resource type SSQL
 	val row:String

--- a/stdlib/db/stringSQL.wyv
+++ b/stdlib/db/stringSQL.wyv
@@ -1,6 +1,4 @@
-resource module stringSQL
-
-require java
+module def stringSQL(java : Java)
 
 type SQL
 	def query():String

--- a/stdlib/platform/java/stdout.wyv
+++ b/stdlib/platform/java/stdout.wyv
@@ -1,6 +1,4 @@
-resource module stdout
-
-require java
+module def stdout(java : Java)
 
 import java:wyvern.stdlib.support.Stdio.stdio
 

--- a/stdlib/platform/python/stdout.wyv
+++ b/stdlib/platform/python/stdout.wyv
@@ -1,6 +1,4 @@
-resource module stdout
-
-require python
+module def stdout(python : Python)
 
 import python:sys
 

--- a/tools/src/wyvern/stdlib/Globals.java
+++ b/tools/src/wyvern/stdlib/Globals.java
@@ -54,8 +54,8 @@ import wyvern.tools.types.extensions.Unit;
 import wyvern.tools.util.EvaluationEnvironment;
 
 public class Globals {
-	public static final NominalType JAVA_IMPORT_TYPE = new NominalType("system", "java");
-    public static final NominalType PYTHON_IMPORT_TYPE = new NominalType("system", "python");
+	public static final NominalType JAVA_IMPORT_TYPE = new NominalType("system", "Java");
+    public static final NominalType PYTHON_IMPORT_TYPE = new NominalType("system", "Python");
 	public static final boolean checkRuntimeTypes = false;
 	private static final Set<String> javaWhiteList = new HashSet<String>();
 	
@@ -121,8 +121,8 @@ public class Globals {
 		genCtx = new TypeGenContext("String", "system", genCtx);
 		genCtx = new TypeGenContext("Boolean", "system", genCtx);
 		genCtx = new TypeGenContext("Dyn", "system", genCtx);
-		genCtx = new TypeGenContext("java", "system", genCtx);
-		genCtx = new TypeGenContext("python", "system", genCtx);
+		genCtx = new TypeGenContext("Java", "system", genCtx);
+		genCtx = new TypeGenContext("Python", "system", genCtx);
 		genCtx = GenUtil.ensureJavaTypesPresent(genCtx);
 		return genCtx;
 	}
@@ -154,8 +154,8 @@ public class Globals {
 		declTypes.add(new ConcreteTypeMember("Unit", Util.unitType()));
 		declTypes.add(new AbstractTypeMember("String"));
 		declTypes.add(new ConcreteTypeMember("Dyn", new DynamicType()));
-		declTypes.add(new AbstractTypeMember("java", true));
-		declTypes.add(new AbstractTypeMember("python"));
+		declTypes.add(new AbstractTypeMember("Java", true));
+		declTypes.add(new AbstractTypeMember("Python"));
 		ValueType systemType = new StructuralType("system", declTypes);
 		return systemType;
 	}
@@ -180,8 +180,8 @@ public class Globals {
 		decls.add(new TypeDeclaration("Unit", new NominalType("this", "Unit"), FileLocation.UNKNOWN));
 		decls.add(new TypeDeclaration("String", new NominalType("this", "String"), FileLocation.UNKNOWN));
 		decls.add(new TypeDeclaration("Dyn", new DynamicType(), FileLocation.UNKNOWN));
-		decls.add(new TypeDeclaration("java", new NominalType("this", "java"), FileLocation.UNKNOWN));
-		decls.add(new TypeDeclaration("python", new NominalType("this", "python"), FileLocation.UNKNOWN));
+		decls.add(new TypeDeclaration("Java", new NominalType("this", "Java"), FileLocation.UNKNOWN));
+		decls.add(new TypeDeclaration("Python", new NominalType("this", "Python"), FileLocation.UNKNOWN));
 		ObjectValue systemVal = new ObjectValue(decls, "this", getSystemType(), null, null, EvalContext.empty());
 		return systemVal;
 	}

--- a/tools/src/wyvern/tools/parsing/coreparser/WyvernParser.jj
+++ b/tools/src/wyvern/tools/parsing/coreparser/WyvernParser.jj
@@ -170,7 +170,7 @@ AST CompilationUnit() :
 { AST exp; Token id; AST moduleArgs=null; Type t; boolean isResource = false; }
 {
   LOOKAHEAD(2)
-  <MODULE> <DEF> id = <IDENTIFIER> <LPAREN> [ moduleArgs = ModuleArgs() ] <RPAREN> OptType() <NEWLINE> exp = ModuleBody(true) {
+  <MODULE> <DEF> id = <IDENTIFIER> <LPAREN> [ moduleArgs = ModuleArgs() ] <RPAREN> OptType() <NEWLINE> exp = ModuleBody() {
 	if (moduleArgs == null) {
 	   return build.moduleDecl(id.image, exp, loc(id), true);
 	} else {
@@ -178,11 +178,11 @@ AST CompilationUnit() :
 	}
   }
 |
-  <MODULE> id = <IDENTIFIER> OptType() <NEWLINE> exp = ModuleBody(true) {
+  <MODULE> id = <IDENTIFIER> OptType() <NEWLINE> exp = ModuleBody() {
 	return build.moduleDecl(id.image, exp, loc(id), isResource);
   }
 |
-  exp = ModuleBody(false)  { return exp; }
+  exp = TopLevelCode()  { return exp; }
 }
 
 AST ModuleArgs() :
@@ -214,14 +214,22 @@ Type OptType() :
   /* nothing */ { return null; }
 }
 
-AST ModuleBody(boolean inModule) :
+AST ModuleBody() :
 { AST ast; AST decl; }
 {
-  ast = DeclSequence(inModule)  { return ast; }
+  ast = DeclSequence(true)  { return ast; }
 |
-  decl = RequireDecl() ast = ModuleBody(inModule) { return build.sequence(decl,ast,inModule); }
+  decl = ImportDecl() ast = ModuleBody() { return build.sequence(decl,ast,true); }
+}
+
+AST TopLevelCode() :
+{ AST ast; AST decl; }
+{
+  ast = DeclSequence(false)  { return ast; }
 |
-  decl = ImportDecl() ast = ModuleBody(inModule) { return build.sequence(decl,ast,inModule); }
+  decl = RequireDecl() ast = TopLevelCode() { return build.sequence(decl,ast,false); }
+|
+  decl = ImportDecl() ast = TopLevelCode() { return build.sequence(decl,ast,false); }
 }
 
 AST RequireDecl() :
@@ -230,6 +238,7 @@ AST RequireDecl() :
   t=<REQUIRE> uri = Uri() [<AS> name = <IDENTIFIER>] <NEWLINE>
     { return build.importDecl(uri, loc(t), name, true, false); }
 }
+
 
 AST ImportDecl() :
 { URI uri; Token t; Token name = null; Token meta = null; }

--- a/tools/src/wyvern/tools/parsing/coreparser/WyvernParser.jj
+++ b/tools/src/wyvern/tools/parsing/coreparser/WyvernParser.jj
@@ -167,12 +167,15 @@ TOKEN : /* Literals */
 
 /** Root production. */
 AST CompilationUnit() :
-{ AST exp; Token id; boolean isResource = false; }
+{ AST exp; Token id; AST moduleArgs=null; Type t; boolean isResource = false; }
 {
   LOOKAHEAD(2)
-  <RESOURCE> {isResource = true;} 
-  <MODULE> id = <IDENTIFIER> OptType() <NEWLINE> exp = ModuleBody(true) {
-	return build.moduleDecl(id.image, exp, loc(id), isResource);
+  <MODULE> <DEF> id = <IDENTIFIER> <LPAREN> [ moduleArgs = ModuleArgs() ] <RPAREN> OptType() <NEWLINE> exp = ModuleBody(true) {
+	if (moduleArgs == null) {
+	   return build.moduleDecl(id.image, exp, loc(id), true);
+	} else {
+	   return build.moduleDecl(id.image, build.sequence(moduleArgs,exp,true), loc(id), true);
+	}
   }
 |
   <MODULE> id = <IDENTIFIER> OptType() <NEWLINE> exp = ModuleBody(true) {
@@ -180,6 +183,27 @@ AST CompilationUnit() :
   }
 |
   exp = ModuleBody(false)  { return exp; }
+}
+
+AST ModuleArgs() :
+{ AST arg; AST args=null; }
+{
+  arg = ModuleArg() {
+      args = build.sequence(args,arg,true);
+  }
+  ( <COMMA> arg = ModuleArg() {
+      args = build.sequence(args,arg,true);
+    }
+  )*
+  { return args; }
+}
+
+AST ModuleArg() :
+{ Token name; URI uri; }
+{
+  name = <IDENTIFIER> <COLON> uri = Uri() {
+      return build.importDecl(uri, loc(name), name, true, false);
+  }
 }
 
 Type OptType() :

--- a/tools/src/wyvern/tools/parsing/coreparser/WyvernParser.jj
+++ b/tools/src/wyvern/tools/parsing/coreparser/WyvernParser.jj
@@ -167,7 +167,7 @@ TOKEN : /* Literals */
 
 /** Root production. */
 AST CompilationUnit() :
-{ AST exp; Token id; AST moduleArgs=null; Type t; boolean isResource = false; }
+{ AST exp; Token id; AST moduleArgs=null; boolean isResource = false; }
 {
   LOOKAHEAD(2)
   <MODULE> <DEF> id = <IDENTIFIER> <LPAREN> [ moduleArgs = ModuleArgs() ] <RPAREN> OptType() <NEWLINE> exp = ModuleBody() {

--- a/tools/src/wyvern/tools/tests/Figures.java
+++ b/tools/src/wyvern/tools/tests/Figures.java
@@ -1,33 +1,15 @@
 package wyvern.tools.tests;
 
-import java.util.LinkedList;
-import java.util.List;
-
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import wyvern.stdlib.Globals;
-import wyvern.target.corewyvernIL.expression.Expression;
-import wyvern.target.corewyvernIL.expression.FieldGet;
 import wyvern.target.corewyvernIL.expression.IntegerLiteral;
-import wyvern.target.corewyvernIL.expression.Value;
-import wyvern.target.corewyvernIL.expression.Variable;
-import wyvern.target.corewyvernIL.support.EvalContext;
-import wyvern.target.corewyvernIL.support.GenContext;
-import wyvern.target.corewyvernIL.support.GenUtil;
-import wyvern.target.corewyvernIL.support.TypeContext;
-import wyvern.target.corewyvernIL.support.TypeGenContext;
 import wyvern.target.corewyvernIL.support.Util;
-import wyvern.target.corewyvernIL.type.NominalType;
-import wyvern.target.corewyvernIL.type.ValueType;
 import wyvern.tools.imports.extensions.WyvernResolver;
 import wyvern.tools.parsing.coreparser.ParseException;
 import wyvern.tools.tests.suites.RegressionTests;
 import wyvern.tools.tests.tagTests.TestUtil;
-import wyvern.tools.typedAST.abs.Declaration;
-import wyvern.tools.typedAST.interfaces.TypedAST;
 
 @Category(RegressionTests.class)
 public class Figures {

--- a/tools/src/wyvern/tools/tests/ILTests.java
+++ b/tools/src/wyvern/tools/tests/ILTests.java
@@ -1,7 +1,6 @@
 package wyvern.tools.tests;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -15,7 +14,6 @@ import org.junit.experimental.categories.Category;
 import wyvern.stdlib.Globals;
 import wyvern.target.corewyvernIL.VarBinding;
 import wyvern.target.corewyvernIL.decl.DefDeclaration;
-import wyvern.target.corewyvernIL.decltype.DeclType;
 import wyvern.target.corewyvernIL.expression.Bind;
 import wyvern.target.corewyvernIL.expression.Expression;
 import wyvern.target.corewyvernIL.expression.FieldGet;
@@ -27,13 +25,10 @@ import wyvern.target.corewyvernIL.expression.Value;
 import wyvern.target.corewyvernIL.expression.Variable;
 import wyvern.target.corewyvernIL.modules.Module;
 import wyvern.target.corewyvernIL.modules.TypedModuleSpec;
-import wyvern.target.corewyvernIL.support.EmptyGenContext;
 import wyvern.target.corewyvernIL.support.EvalContext;
 import wyvern.target.corewyvernIL.support.GenContext;
-import wyvern.target.corewyvernIL.support.GenUtil;
 import wyvern.target.corewyvernIL.support.InterpreterState;
 import wyvern.target.corewyvernIL.support.TypeContext;
-import wyvern.target.corewyvernIL.support.TypeGenContext;
 import wyvern.target.corewyvernIL.support.Util;
 import wyvern.target.corewyvernIL.type.NominalType;
 import wyvern.target.corewyvernIL.type.ValueType;
@@ -406,7 +401,7 @@ public class ILTests {
 	@Test
 	public void testMultipleModules() throws ParseException {
 		
-		String[] fileList = {"A.wyt", "B.wyt", "D.wyt", "A.wyv", "D.wyv", "B.wyv", "main.wyv"};
+		String[] fileList = {"One.wyt", "Two.wyt", "Three.wyt", "one.wyv", "two.wyv", "three.wyv", "main.wyv"};
 		GenContext genCtx = Globals.getStandardGenContext();
 		//genCtx = new TypeGenContext("Int", "system", genCtx);
 		
@@ -617,8 +612,7 @@ public class ILTests {
 	
 	@Test
 	public void testJavaImport1() throws ParseException {
-		String input = "resource module main\n\n"
-					 + "require java\n\n"
+		String input = "module def main(java : Java)\n\n"
 //					 + "import testcode/Adder\n\n"
 //					 + "type Adder\n"
 //					 + "    def addOne(i:system.Int):system.Int\n\n"
@@ -645,12 +639,12 @@ public class ILTests {
 	
 	@Test
 	public void testBool() throws ParseException {
-		doTestScript("Bool.wyv", Util.intType(), new IntegerLiteral(5));
+		doTestScript("bool.wyv", Util.intType(), new IntegerLiteral(5));
 	}
 	
 	@Test
 	public void testList() throws ParseException {
-		doTestScript("List.wyv", Util.intType(), new IntegerLiteral(5));
+		doTestScript("list.wyv", Util.intType(), new IntegerLiteral(5));
 	}
 	
 	@Test
@@ -660,7 +654,7 @@ public class ILTests {
 	
 	@Test
 	public void testListClient() throws ParseException {
-		doTestScriptModularly("modules.module.ListClient", Util.intType(), new IntegerLiteral(5));
+		doTestScriptModularly("modules.module.listClient", Util.intType(), new IntegerLiteral(5));
 	}
 	
 	private void doTestScript(String fileName, ValueType expectedType, Value expectedValue) throws ParseException {
@@ -716,8 +710,7 @@ public class ILTests {
 	
 	@Test
 	public void testJavaImport2() throws ParseException {
-		String input = "resource module main\n\n"
-					 + "require java\n\n"
+		String input = "module def main(java : Java)\n\n"
 //					 + "import testcode/Adder\n\n"
 //					 + "type Adder\n"
 //					 + "    def addOne(i:system.Int):system.Int\n\n"
@@ -770,7 +763,7 @@ public class ILTests {
 	// tests import-dependent types
 	@Test
 	public void testIDT() throws ParseException {
-		doTestScriptModularly("modules.IDT3", Util.intType(), new IntegerLiteral(3));
+		doTestScriptModularly("modules.idtDriver", Util.intType(), new IntegerLiteral(3));
 	}
 	
 	@Test

--- a/tools/src/wyvern/tools/tests/Illustrations.java
+++ b/tools/src/wyvern/tools/tests/Illustrations.java
@@ -8,7 +8,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import wyvern.stdlib.Globals;
 import wyvern.target.corewyvernIL.expression.Expression;
 import wyvern.target.corewyvernIL.expression.FieldGet;
 import wyvern.target.corewyvernIL.expression.IntegerLiteral;
@@ -42,32 +41,7 @@ public class Illustrations {
 
 	@Test
 	public void testFigure5Corrected() throws ParseException {
-		/*
-		String[] fileList = {"FileIO.wyt", "FileIO.wyv", "SigLogger.wyt", "Logger.wyv", "WavyUnderlineV3.wyv", "example5.wyv", "example5driver.wyv", };
-		GenContext genCtx = Globals.getStandardGenContext();
-		TypeContext ctx = Globals.getStandardTypeContext();
-		//GenContext genCtx = GenContext.empty().extend("system", new Variable("system"), new NominalType("", "system"));
-		
-		List<wyvern.target.corewyvernIL.decl.Declaration> decls = new LinkedList<wyvern.target.corewyvernIL.decl.Declaration>();
-		
-		for(String fileName : fileList) {
-			System.out.println(fileName);
-			String source = TestUtil.readFile(PATH + fileName);
-			TypedAST ast = TestUtil.getNewAST(source);
-			wyvern.target.corewyvernIL.decl.Declaration decl = ((Declaration) ast).topLevelGen(genCtx, null);
-			decls.add(decl);
-			genCtx = GenUtil.link(genCtx, decl);
-		}
-		
-		Expression mainProgram = GenUtil.genExp(decls, genCtx);
-		// after genExp the modules are transferred into an object. We need to evaluate one field of the main object
-		Expression program = new FieldGet(mainProgram, "x", null); 
-		
-		ValueType t = program.typeCheck(ctx);
-		Value v = program.interpret(EvalContext.empty());
-    	IntegerLiteral five = new IntegerLiteral(5);
-		Assert.assertEquals(five, v);
-		*/
+		// uses "FileIO.wyt", "fileIO.wyv", "Logger.wyt", "logger.wyv", "wavyUnderlineV3.wyv", "example5.wyv", "example5driver.wyv"
 		ILTests.doTestScriptModularly("illustrations.example5driver",
 				Util.intType(),
 				new IntegerLiteral(5));
@@ -76,8 +50,8 @@ public class Illustrations {
 	@Test(expected=RuntimeException.class)
 	public void testFigure5() throws ParseException {
 		
-		String[] fileList = {"FileIO.wyt", "FileIO.wyv", "SigLogger.wyt",
-							"Logger.wyv", "WavyUnderlineV3Fig5.wyv",
+		String[] fileList = {"FileIO.wyt", "fileIO.wyv", "Logger.wyt",
+							"logger.wyv", "wavyUnderlineV3Fig5.wyv",
 							"example5.wyv", "example5driver.wyv", };
 		GenContext genCtx = GenContext.empty().extend("system", new Variable("system"), new NominalType("", "system"));
 		genCtx = new TypeGenContext("Int", "system", genCtx);
@@ -86,7 +60,6 @@ public class Illustrations {
 		List<wyvern.target.corewyvernIL.decl.Declaration> decls = new LinkedList<wyvern.target.corewyvernIL.decl.Declaration>();
 		
 		for(String fileName : fileList) {
-			System.out.println(fileName);
 			String source = TestUtil.readFile(PATH + fileName);
 			TypedAST ast = TestUtil.getNewAST(source, "test input");
 			wyvern.target.corewyvernIL.decl.Declaration decl = ((Declaration) ast).topLevelGen(genCtx, null);
@@ -108,8 +81,8 @@ public class Illustrations {
 	@Test(expected=RuntimeException.class)
 	public void testFigure3() throws ParseException {
 		
-		String[] fileList = {"FileIO.wyt", "FileIO.wyv", "SigLogger.wyt",
-							"Logger.wyv", "WavyUnderlineV1.wyv",
+		String[] fileList = {"FileIO.wyt", "fileIO.wyv", "Logger.wyt",
+							"logger.wyv", "wavyUnderlineV1.wyv",
 							"example5Fig3.wyv", "example5driver.wyv", };
 		GenContext genCtx = GenContext.empty().extend("system", new Variable("system"), new NominalType("", "system"));
 		genCtx = new TypeGenContext("Int", "system", genCtx);
@@ -118,7 +91,6 @@ public class Illustrations {
 		List<wyvern.target.corewyvernIL.decl.Declaration> decls = new LinkedList<wyvern.target.corewyvernIL.decl.Declaration>();
 		
 		for(String fileName : fileList) {
-			System.out.println(fileName);
 			String source = TestUtil.readFile(PATH + fileName);
 			TypedAST ast = TestUtil.getNewAST(source, "test input");
 			wyvern.target.corewyvernIL.decl.Declaration decl = ((Declaration) ast).topLevelGen(genCtx, null);
@@ -139,30 +111,7 @@ public class Illustrations {
 	
 	@Test
 	public void testFigure2() throws ParseException {
-		/*String[] fileList = {"Lists.wyv", "SigUserInfo.wyt", "UserInfo.wyv", "DocumentLock.wyv", "example2.wyv", };
-		GenContext genCtx = Globals.getStandardGenContext();
-		TypeContext ctx = Globals.getStandardTypeContext();
-
-		List<wyvern.target.corewyvernIL.decl.Declaration> decls = new LinkedList<wyvern.target.corewyvernIL.decl.Declaration>();
-		
-		for(String fileName : fileList) {
-			System.out.println(fileName);
-			String source = TestUtil.readFile(PATH + fileName);
-			TypedAST ast = TestUtil.getNewAST(source);
-			wyvern.target.corewyvernIL.decl.Declaration decl = ((Declaration) ast).topLevelGen(genCtx, null);
-			decls.add(decl);
-			genCtx = GenUtil.link(genCtx, decl);
-		}
-		
-		Expression mainProgram = GenUtil.genExp(decls, genCtx);
-		// after genExp the modules are transferred into an object. We need to evaluate one field of the main object
-		Expression program = new FieldGet(mainProgram, "x", null); 
-		
-		ValueType t = program.typeCheck(ctx);
-		Value v = program.interpret(EvalContext.empty());
-    	IntegerLiteral five = new IntegerLiteral(5);
-		Assert.assertEquals(five, v);
-		*/
+		// uses "lists.wyv", "UserInfo.wyt", "userInfo.wyv", "DocumentLock.wyv", "example2.wyv"
 		ILTests.doTestScriptModularly("illustrations.example2",
 				Util.intType(),
 				new IntegerLiteral(5));
@@ -171,7 +120,7 @@ public class Illustrations {
 	@Test(expected=RuntimeException.class)
 	public void testFigure4() throws ParseException {
 		
-		String[] fileList = {"Lists.wyv", "SigUserInfo.wyt", "UserInfo.wyv", "WavyUnderlineV2.wyv", "fig4.wyv", };
+		String[] fileList = {"lists.wyv", "UserInfo.wyt", "userInfo.wyv", "wavyUnderlineV2.wyv", "example4driver.wyv", };
 		GenContext genCtx = GenContext.empty().extend("system", new Variable("system"), new NominalType("", "system"));
 		genCtx = new TypeGenContext("Int", "system", genCtx);
 		genCtx = new TypeGenContext("Unit", "system", genCtx);
@@ -179,7 +128,6 @@ public class Illustrations {
 		List<wyvern.target.corewyvernIL.decl.Declaration> decls = new LinkedList<wyvern.target.corewyvernIL.decl.Declaration>();
 		
 		for(String fileName : fileList) {
-			System.out.println(fileName);
 			String source = TestUtil.readFile(PATH + fileName);
 			TypedAST ast = TestUtil.getNewAST(source, "test input");
 			wyvern.target.corewyvernIL.decl.Declaration decl = ((Declaration) ast).topLevelGen(genCtx, null);

--- a/tools/src/wyvern/tools/tests/ModuleSystemTests.java
+++ b/tools/src/wyvern/tools/tests/ModuleSystemTests.java
@@ -10,7 +10,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import wyvern.stdlib.Globals;
-import wyvern.target.corewyvernIL.expression.Expression;
 import wyvern.target.corewyvernIL.expression.IExpr;
 import wyvern.target.corewyvernIL.expression.IntegerLiteral;
 import wyvern.target.corewyvernIL.expression.Variable;
@@ -93,16 +92,6 @@ public class ModuleSystemTests {
 	public void testInst() throws ParseException {
 		String program = TestUtil.readFile(PATH + "inst.wyv");
 		TypedAST ast = TestUtil.getNewAST(program, "test input");
-	}
-
-	@Test
-	@Category(CurrentlyBroken.class)
-	public void testDaryaModuleExample() throws ParseException {
-		String program = TestUtil.readFile(PATH + "paper-module-example/Main.wyv");
-		TypedAST ast = TestUtil.getNewAST(program, "test input");
-		WyvernResolver.getInstance().setNewParser(true);
-		ast.typecheck(Globals.getStandardEnv(), Optional.empty());
-		ast.evaluate(Globals.getStandardEvalEnv());
 	}
 
 	/**

--- a/tools/src/wyvern/tools/tests/ModuleSystemTests.java
+++ b/tools/src/wyvern/tools/tests/ModuleSystemTests.java
@@ -119,7 +119,7 @@ public class ModuleSystemTests {
 
 	@Test
 	public void testADT() throws ParseException {
-		ILTests.doTestScriptModularly("modules.ListClient",
+		ILTests.doTestScriptModularly("modules.listClient",
 				Util.intType(),
 				new IntegerLiteral(5));
 	}
@@ -128,7 +128,7 @@ public class ModuleSystemTests {
 	@Category(CurrentlyBroken.class)
 	public void testTransitiveAuthorityBad() throws ParseException {
 
-		String[] fileList = {"Database.wyv", "DatabaseProxy.wyv", "DatabaseClientBad.wyv"};
+		String[] fileList = {"database.wyv", "databaseProxy.wyv", "databaseClientBad.wyv"};
 		GenContext genCtx = GenContext.empty().extend("system", new Variable("system"), new NominalType("", "system"));
 		genCtx = new TypeGenContext("Int", "system", genCtx);
 		genCtx = new TypeGenContext("Unit", "system", genCtx);
@@ -151,7 +151,7 @@ public class ModuleSystemTests {
 	@Category(CurrentlyBroken.class)
 	public void testTransitiveAuthorityGood() throws ParseException {
 
-		String[] fileList = {"Database.wyv", "DatabaseProxy.wyv", "DatabaseClientGood.wyv"};
+		String[] fileList = {"database.wyv", "databaseProxy.wyv", "databaseClientGood.wyv"};
 		GenContext genCtx = GenContext.empty().extend("system", new Variable("system"), new NominalType("", "system"));
 		genCtx = new TypeGenContext("Int", "system", genCtx);
 		genCtx = new TypeGenContext("Unit", "system", genCtx);
@@ -179,13 +179,13 @@ public class ModuleSystemTests {
 		genCtx = new TypeGenContext("Int", "system", genCtx);
 		genCtx = new TypeGenContext("Unit", "system", genCtx);
 	
-		// Load and link Database.wyv.
-		TypedAST astDatabase = TestUtil.getNewAST(TestUtil.readFile(PATH + "Database.wyv"), "test input");
+		// Load and link database.wyv.
+		TypedAST astDatabase = TestUtil.getNewAST(TestUtil.readFile(PATH + "database.wyv"), "test input");
 		wyvern.target.corewyvernIL.decl.Declaration decl = ((Declaration) astDatabase).topLevelGen(genCtx, null);
 		genCtx = GenUtil.link(genCtx, decl);
 		
-		// Interpret DatabaseUser.wyv with Database.wyv in the context.
-		String source = TestUtil.readFile(PATH + "DatabaseUser.wyv");
+		// Interpret databaseUser.wyv with database.wyv in the context.
+		String source = TestUtil.readFile(PATH + "databaseUser.wyv");
 		ExpressionAST ast = (ExpressionAST) TestUtil.getNewAST(source, "test input");
 		IExpr program = ast.generateIL(genCtx, Util.intType(), null);
 		TypeContext ctx = TypeContext.empty();
@@ -204,13 +204,13 @@ public class ModuleSystemTests {
 		genCtx = new TypeGenContext("Int", "system", genCtx);
 		genCtx = new TypeGenContext("Unit", "system", genCtx);
 	
-		// Load and link Database.wyv.
-		TypedAST astDatabase = TestUtil.getNewAST(TestUtil.readFile(PATH + "Database.wyv"), "test input");
+		// Load and link database.wyv.
+		TypedAST astDatabase = TestUtil.getNewAST(TestUtil.readFile(PATH + "database.wyv"), "test input");
 		wyvern.target.corewyvernIL.decl.Declaration decl = ((Declaration) astDatabase).topLevelGen(genCtx, null);
 		genCtx = GenUtil.link(genCtx, decl);
 		
-		// Interpret DatabaseUser.wyv with Database.wyv in the context.
-		String source = TestUtil.readFile(PATH + "DatabaseUserTricky.wyv");
+		// Interpret databaseUser.wyv with database.wyv in the context.
+		String source = TestUtil.readFile(PATH + "databaseUserTricky.wyv");
 		ExpressionAST ast = (ExpressionAST) TestUtil.getNewAST(source, "test input");
 		IExpr program = ast.generateIL(genCtx, Util.intType(), new LinkedList<TypedModuleSpec>());
 		TypeContext ctx = TypeContext.empty();

--- a/tools/src/wyvern/tools/tests/figs/fileIO.wyv
+++ b/tools/src/wyvern/tools/tests/figs/fileIO.wyv
@@ -1,6 +1,5 @@
-resource module fileIO
+module def fileIO(java : Java) : FileIO
 
-require java
 import java:wyvern.tools.tests.Illustrations.nativeFileIO
 
 def read():system.Int

--- a/tools/src/wyvern/tools/tests/figs/logger.wyv
+++ b/tools/src/wyvern/tools/tests/figs/logger.wyv
@@ -1,6 +1,4 @@
-resource module logger
-
-require figs.FileIO as logIO
+module def logger(logIO : figs.FileIO) : Logger
 
 def log(entry : Int) : Int
 	logIO.write(entry)

--- a/tools/src/wyvern/tools/tests/figs/wordCloudFig3.wyv
+++ b/tools/src/wyvern/tools/tests/figs/wordCloudFig3.wyv
@@ -1,7 +1,6 @@
-resource module wordCloudFig3
+module def wordCloudFig3(log : figs.Logger) : WordCloud
 
 import figs.listFactory
-require figs.Logger as log
 
 val words : listFactory.List = listFactory.create()
 

--- a/tools/src/wyvern/tools/tests/figs/wordCloudFig4.wyv
+++ b/tools/src/wyvern/tools/tests/figs/wordCloudFig4.wyv
@@ -1,7 +1,4 @@
-resource module wordCloudFig4
-
-require figs.Logger as log
-require figs.ListFactory2 as list
+module def wordCloudFig4(log : figs.Logger, list : figs.ListFactory2) : WordCloud
 
 val words : list.List = list.create()
 

--- a/tools/src/wyvern/tools/tests/figs/wordProcessor.wyv
+++ b/tools/src/wyvern/tools/tests/figs/wordProcessor.wyv
@@ -1,8 +1,6 @@
-resource module wordProcessor
+module def wordProcessor(io : figs.FileIO) : WordProcessor
 
 import figs.logger
-
-require figs.FileIO as io
 
 val log = logger(io)
 

--- a/tools/src/wyvern/tools/tests/illustrations/DocumentLock.wyv
+++ b/tools/src/wyvern/tools/tests/illustrations/DocumentLock.wyv
@@ -1,7 +1,0 @@
-resource module DocumentLock
-
-require illustrations.SigUserInfo as uInfo
-
-def sign() : Int
-	val signee : Int = uInfo.getName()
-	signee

--- a/tools/src/wyvern/tools/tests/illustrations/FileIO.wyt
+++ b/tools/src/wyvern/tools/tests/illustrations/FileIO.wyt
@@ -1,3 +1,3 @@
-resource type SigFileIO
+resource type FileIO
 	def read():system.Int
 	def write(x:Int):Int

--- a/tools/src/wyvern/tools/tests/illustrations/Line.wyt
+++ b/tools/src/wyvern/tools/tests/illustrations/Line.wyt
@@ -1,2 +1,0 @@
-type Line
-	val contents : Int

--- a/tools/src/wyvern/tools/tests/illustrations/Logger.wyt
+++ b/tools/src/wyvern/tools/tests/illustrations/Logger.wyt
@@ -1,2 +1,2 @@
-resource type SigLogger
+resource type Logger
 	def log(x : Int) : Int

--- a/tools/src/wyvern/tools/tests/illustrations/Logger.wyv
+++ b/tools/src/wyvern/tools/tests/illustrations/Logger.wyv
@@ -1,6 +1,0 @@
-resource module Logger
-
-require illustrations.SigFileIO as logIO
-
-def log(entry : Int) : Int
-	logIO.write(entry)

--- a/tools/src/wyvern/tools/tests/illustrations/UserInfo.wyt
+++ b/tools/src/wyvern/tools/tests/illustrations/UserInfo.wyt
@@ -1,3 +1,3 @@
-resource type SigUserInfo
+resource type UserInfo
 	def init(uName : Int) : Int
 	def getName() : Int

--- a/tools/src/wyvern/tools/tests/illustrations/WavyUnderlineV1.wyv
+++ b/tools/src/wyvern/tools/tests/illustrations/WavyUnderlineV1.wyv
@@ -1,6 +1,0 @@
-resource module WavyUnderlineV1
-
-require SigFileIO as io
-
-def underlineIt() : system.Int
-	io.write(10)

--- a/tools/src/wyvern/tools/tests/illustrations/WavyUnderlineV2.wyv
+++ b/tools/src/wyvern/tools/tests/illustrations/WavyUnderlineV2.wyv
@@ -1,6 +1,0 @@
-resource module WavyUnderlineV2
-
-import SigUserInfo as userInfo
-
-def leakUserInfo() : system.Int
-	userInfo.getName()

--- a/tools/src/wyvern/tools/tests/illustrations/WavyUnderlineV3.wyv
+++ b/tools/src/wyvern/tools/tests/illustrations/WavyUnderlineV3.wyv
@@ -1,6 +1,0 @@
-resource module WavyUnderlineV3
-
-require illustrations.SigLogger as logger
-
-def underlineIt() : system.Int
-	logger.log(4)

--- a/tools/src/wyvern/tools/tests/illustrations/WavyUnderlineV3Fig5.wyv
+++ b/tools/src/wyvern/tools/tests/illustrations/WavyUnderlineV3Fig5.wyv
@@ -1,6 +1,0 @@
-resource module WavyUnderlineV3
-
-require SigLogger as logger
-
-def underlineIt() : system.Int
-	logger.logIO.write(entry)

--- a/tools/src/wyvern/tools/tests/illustrations/documentLock.wyv
+++ b/tools/src/wyvern/tools/tests/illustrations/documentLock.wyv
@@ -1,0 +1,5 @@
+module def documentLock(uInfo : illustrations.UserInfo)
+
+def sign() : Int
+	val signee : Int = uInfo.getName()
+	signee

--- a/tools/src/wyvern/tools/tests/illustrations/example2.wyv
+++ b/tools/src/wyvern/tools/tests/illustrations/example2.wyv
@@ -1,8 +1,8 @@
-import illustrations.UserInfo
-import illustrations.DocumentLock
+import illustrations.userInfo
+import illustrations.documentLock
 
-val uInfo = UserInfo()
-val docLock = DocumentLock(uInfo)
+val uInfo = userInfo()
+val docLock = documentLock(uInfo)
 
 val x : Int = docLock.sign()
 x

--- a/tools/src/wyvern/tools/tests/illustrations/example4driver.wyv
+++ b/tools/src/wyvern/tools/tests/illustrations/example4driver.wyv
@@ -1,0 +1,4 @@
+instantiate userInfo() as uInfo
+instantiate wavyUnderlineV2() as wavyUnderliner
+
+val x : Int = wavyUnderliner.leakUserInfo()

--- a/tools/src/wyvern/tools/tests/illustrations/example5.wyv
+++ b/tools/src/wyvern/tools/tests/illustrations/example5.wyv
@@ -1,11 +1,9 @@
-resource module example5
+module def example5(io : illustrations.FileIO)
 
-import illustrations.Logger
-import illustrations.WavyUnderlineV3
+import illustrations.logger
+import illustrations.wavyUnderlineV3
 
-require illustrations.SigFileIO as io
-
-val logger = Logger(io)
-val wavyUnderliner = WavyUnderlineV3(logger)
+val log = logger(io)
+val wavyUnderliner = wavyUnderlineV3(log)
 
 val x : system.Int = wavyUnderliner.underlineIt()

--- a/tools/src/wyvern/tools/tests/illustrations/example5Fig3.wyv
+++ b/tools/src/wyvern/tools/tests/illustrations/example5Fig3.wyv
@@ -1,7 +1,6 @@
-resource module Example5
+module def example5(fileIO : illustrations.FileIO)
 
-require SigFileIO as fileIO
-instantiate Logger(fileIO) as logger
-instantiate WavyUnderlineV1() as wavyUnderliner
+instantiate logger(fileIO) as logger
+instantiate wavyUnderlineV1() as wavyUnderliner
 
 val x : system.Int = wavyUnderliner.underlineIt()

--- a/tools/src/wyvern/tools/tests/illustrations/example5driver.wyv
+++ b/tools/src/wyvern/tools/tests/illustrations/example5driver.wyv
@@ -1,9 +1,9 @@
 require java
 
-import illustrations.FileIO
+import illustrations.fileIO
 import illustrations.example5
 
-val fileIO = FileIO(java)
-val ex5 = example5(fileIO)
+val fio = fileIO(java)
+val ex5 = example5(fio)
 
 ex5.x

--- a/tools/src/wyvern/tools/tests/illustrations/fig4.wyv
+++ b/tools/src/wyvern/tools/tests/illustrations/fig4.wyv
@@ -1,6 +1,0 @@
-resource module main
-
-instantiate UserInfo() as uInfo
-instantiate WavyUnderlineV2() as wavyUnderliner
-
-val x : Int = wavyUnderliner.leakUserInfo()

--- a/tools/src/wyvern/tools/tests/illustrations/fileIO.wyv
+++ b/tools/src/wyvern/tools/tests/illustrations/fileIO.wyv
@@ -1,6 +1,5 @@
-resource module FileIO
+module def fileIO(java : Java) : FileIO
 
-require java
 import java:wyvern.tools.tests.Illustrations.nativeFileIO
 
 def read():system.Int

--- a/tools/src/wyvern/tools/tests/illustrations/lists.wyv
+++ b/tools/src/wyvern/tools/tests/illustrations/lists.wyv
@@ -1,4 +1,4 @@
-module Lists
+module lists
 
 val listFactory = new
 	type List

--- a/tools/src/wyvern/tools/tests/illustrations/logger.wyv
+++ b/tools/src/wyvern/tools/tests/illustrations/logger.wyv
@@ -1,0 +1,4 @@
+module def logger(logIO : illustrations.FileIO)
+
+def log(entry : Int) : Int
+	logIO.write(entry)

--- a/tools/src/wyvern/tools/tests/illustrations/userInfo.wyv
+++ b/tools/src/wyvern/tools/tests/illustrations/userInfo.wyv
@@ -1,8 +1,8 @@
-resource module UserInfo
+module def userInfo() : UserInfo
 
-import illustrations.Lists
+import illustrations.lists
 
-val listFactory = Lists.listFactory
+val listFactory = lists.listFactory
 
 val name : Int = 5
 

--- a/tools/src/wyvern/tools/tests/illustrations/wavyUnderlineV1.wyv
+++ b/tools/src/wyvern/tools/tests/illustrations/wavyUnderlineV1.wyv
@@ -1,0 +1,4 @@
+module def wavyUnderlineV1(io : illustrations.FileIO)
+
+def underlineIt() : system.Int
+	io.write(10)

--- a/tools/src/wyvern/tools/tests/illustrations/wavyUnderlineV2.wyv
+++ b/tools/src/wyvern/tools/tests/illustrations/wavyUnderlineV2.wyv
@@ -1,0 +1,6 @@
+module def wavyUnderlineV2()
+
+import illustrations.userInfo as userInfo
+
+def leakUserInfo() : system.Int
+	userInfo.getName()

--- a/tools/src/wyvern/tools/tests/illustrations/wavyUnderlineV3.wyv
+++ b/tools/src/wyvern/tools/tests/illustrations/wavyUnderlineV3.wyv
@@ -1,0 +1,4 @@
+module def wavyUnderlineV3(logger : illustrations.Logger)
+
+def underlineIt() : system.Int
+	logger.log(4)

--- a/tools/src/wyvern/tools/tests/illustrations/wavyUnderlineV3Fig5.wyv
+++ b/tools/src/wyvern/tools/tests/illustrations/wavyUnderlineV3Fig5.wyv
@@ -1,0 +1,4 @@
+module def wavyUnderlineV3(logger : illustrations.Logger)
+
+def underlineIt() : system.Int
+	logger.logIO.write(entry)

--- a/tools/src/wyvern/tools/tests/modules/Actual.wyv
+++ b/tools/src/wyvern/tools/tests/modules/Actual.wyv
@@ -1,3 +1,3 @@
-resource module Actual : modules.Formal
+module def actual() : modules.Formal
 
 def f():Int = 5

--- a/tools/src/wyvern/tools/tests/modules/Database.wyv
+++ b/tools/src/wyvern/tools/tests/modules/Database.wyv
@@ -1,3 +1,3 @@
-resource module Database
+module def database()
 
 var contents : Int = 0

--- a/tools/src/wyvern/tools/tests/modules/DatabaseClientBad.wyv
+++ b/tools/src/wyvern/tools/tests/modules/DatabaseClientBad.wyv
@@ -1,6 +1,4 @@
-resource module DatabaseClient
-
-require DatabaseProxy as proxy
+module def databaseClient(proxy : modules.DatabaseProxy)
 
 def update () : Unit
 	proxy.db.contents = 42

--- a/tools/src/wyvern/tools/tests/modules/DatabaseClientGood.wyv
+++ b/tools/src/wyvern/tools/tests/modules/DatabaseClientGood.wyv
@@ -1,6 +1,4 @@
-resource module DatabaseClient
-
-require DatabaseProxy as proxy
+module def databaseClient(proxy : modules.DatabaseProxy)
 
 def update () : Unit
 	proxy.increment()

--- a/tools/src/wyvern/tools/tests/modules/DatabaseProxy.wyv
+++ b/tools/src/wyvern/tools/tests/modules/DatabaseProxy.wyv
@@ -1,6 +1,4 @@
-resource module DatabaseProxy
-
-require Database as db
+module def databaseProxy(db : modules.Database)
 
 def increment():Unit
 	db.contents = db.contents + 1

--- a/tools/src/wyvern/tools/tests/modules/DatabaseUser.wyv
+++ b/tools/src/wyvern/tools/tests/modules/DatabaseUser.wyv
@@ -1,5 +1,4 @@
+require database
 
-require Database
-
-Database.contents = 10
-Database.contents
+database.contents = 10
+database.contents

--- a/tools/src/wyvern/tools/tests/modules/DatabaseUserTricky.wyv
+++ b/tools/src/wyvern/tools/tests/modules/DatabaseUserTricky.wyv
@@ -1,9 +1,8 @@
+require database
 
-require Database
+database.contents = 0
 
-Database.contents = 0
-
-val db = Database
+val db = database
 db.contents = 10
 
-Database.contents
+database.contents

--- a/tools/src/wyvern/tools/tests/modules/IDT1.wyv
+++ b/tools/src/wyvern/tools/tests/modules/IDT1.wyv
@@ -1,6 +1,6 @@
 // import-dependent type test, part 1
 
-module IDT1
+module idt1
 
 type MyADT = Unit
 

--- a/tools/src/wyvern/tools/tests/modules/IDT2.wyv
+++ b/tools/src/wyvern/tools/tests/modules/IDT2.wyv
@@ -1,10 +1,10 @@
 // import-dependent type test, part 2
 
-module IDT2
+module idt2
 
-import modules.IDT1
+import modules.idt1
 
-type MyADT = IDT1.MyADT
+type MyADT = idt1.MyADT
 
 val baz = new
-	def bar(m:MyADT):Int = IDT1.foo(m)
+	def bar(m:MyADT):Int = idt1.foo(m)

--- a/tools/src/wyvern/tools/tests/modules/ListClient.wyv
+++ b/tools/src/wyvern/tools/tests/modules/ListClient.wyv
@@ -1,5 +1,5 @@
-import modules.Lists
+import modules.lists
 
-val list = Lists.create()
+val list = lists.create()
 
 list.contents

--- a/tools/src/wyvern/tools/tests/modules/Lists.wyv
+++ b/tools/src/wyvern/tools/tests/modules/Lists.wyv
@@ -1,4 +1,4 @@
-module Lists
+module lists
 
 type List
 	val contents : Int

--- a/tools/src/wyvern/tools/tests/modules/actual.wyv
+++ b/tools/src/wyvern/tools/tests/modules/actual.wyv
@@ -1,0 +1,3 @@
+module def actual() : modules.Formal
+
+def f():Int = 5

--- a/tools/src/wyvern/tools/tests/modules/database.wyv
+++ b/tools/src/wyvern/tools/tests/modules/database.wyv
@@ -1,0 +1,3 @@
+module def database()
+
+var contents : Int = 0

--- a/tools/src/wyvern/tools/tests/modules/databaseClientBad.wyv
+++ b/tools/src/wyvern/tools/tests/modules/databaseClientBad.wyv
@@ -1,0 +1,4 @@
+module def databaseClient(proxy : modules.DatabaseProxy)
+
+def update () : Unit
+	proxy.db.contents = 42

--- a/tools/src/wyvern/tools/tests/modules/databaseClientGood.wyv
+++ b/tools/src/wyvern/tools/tests/modules/databaseClientGood.wyv
@@ -1,0 +1,4 @@
+module def databaseClient(proxy : modules.DatabaseProxy)
+
+def update () : Unit
+	proxy.increment()

--- a/tools/src/wyvern/tools/tests/modules/databaseProxy.wyv
+++ b/tools/src/wyvern/tools/tests/modules/databaseProxy.wyv
@@ -1,0 +1,4 @@
+module def databaseProxy(db : modules.Database)
+
+def increment():Unit
+	db.contents = db.contents + 1

--- a/tools/src/wyvern/tools/tests/modules/databaseUser.wyv
+++ b/tools/src/wyvern/tools/tests/modules/databaseUser.wyv
@@ -1,0 +1,4 @@
+require database
+
+database.contents = 10
+database.contents

--- a/tools/src/wyvern/tools/tests/modules/databaseUserTricky.wyv
+++ b/tools/src/wyvern/tools/tests/modules/databaseUserTricky.wyv
@@ -1,0 +1,8 @@
+require database
+
+database.contents = 0
+
+val db = database
+db.contents = 10
+
+database.contents

--- a/tools/src/wyvern/tools/tests/modules/idt1.wyv
+++ b/tools/src/wyvern/tools/tests/modules/idt1.wyv
@@ -1,0 +1,7 @@
+// import-dependent type test, part 1
+
+module idt1
+
+type MyADT = Unit
+
+def foo(m:MyADT):Int = 3

--- a/tools/src/wyvern/tools/tests/modules/idt2.wyv
+++ b/tools/src/wyvern/tools/tests/modules/idt2.wyv
@@ -1,0 +1,10 @@
+// import-dependent type test, part 2
+
+module idt2
+
+import modules.idt1
+
+type MyADT = idt1.MyADT
+
+val baz = new
+	def bar(m:MyADT):Int = idt1.foo(m)

--- a/tools/src/wyvern/tools/tests/modules/idtDriver.wyv
+++ b/tools/src/wyvern/tools/tests/modules/idtDriver.wyv
@@ -1,6 +1,6 @@
 // import-dependent type test, part 3
 
-import modules.IDT2
+import modules.idt2
 
-val bark = IDT2.baz
+val bark = idt2.baz
 3

--- a/tools/src/wyvern/tools/tests/modules/listClient.wyv
+++ b/tools/src/wyvern/tools/tests/modules/listClient.wyv
@@ -1,0 +1,5 @@
+import modules.lists
+
+val list = lists.create()
+
+list.contents

--- a/tools/src/wyvern/tools/tests/modules/lists.wyv
+++ b/tools/src/wyvern/tools/tests/modules/lists.wyv
@@ -1,0 +1,8 @@
+module lists
+
+type List
+	val contents : Int
+
+def create():List
+	new
+		val contents = 5

--- a/tools/src/wyvern/tools/tests/modules/module/B.wyt
+++ b/tools/src/wyvern/tools/tests/modules/module/B.wyt
@@ -1,2 +1,0 @@
-resource type sigB 
-	val k : Int

--- a/tools/src/wyvern/tools/tests/modules/module/B.wyv
+++ b/tools/src/wyvern/tools/tests/modules/module/B.wyv
@@ -1,4 +1,0 @@
-resource module B : sigB
-import D 
-require sigA as objA
-val k : system.Int = objA.m(3)

--- a/tools/src/wyvern/tools/tests/modules/module/One.wyt
+++ b/tools/src/wyvern/tools/tests/modules/module/One.wyt
@@ -1,3 +1,3 @@
-resource type sigA
+resource type One
 	val f : Int
 	def m(y : system.Int) : system.Int

--- a/tools/src/wyvern/tools/tests/modules/module/Three.wyt
+++ b/tools/src/wyvern/tools/tests/modules/module/Three.wyt
@@ -1,2 +1,2 @@
-resource type sigD
+resource type Three
 	def m(y : Int) : Int

--- a/tools/src/wyvern/tools/tests/modules/module/Two.wyt
+++ b/tools/src/wyvern/tools/tests/modules/module/Two.wyt
@@ -1,0 +1,2 @@
+resource type Two 
+	val k : Int

--- a/tools/src/wyvern/tools/tests/modules/module/bigint.wyv
+++ b/tools/src/wyvern/tools/tests/modules/module/bigint.wyv
@@ -1,4 +1,3 @@
-//resource module main
 require java
 
 import java:wyvern.tools.tests.ILTests.importTest

--- a/tools/src/wyvern/tools/tests/modules/module/bool.wyv
+++ b/tools/src/wyvern/tools/tests/modules/module/bool.wyv
@@ -1,0 +1,29 @@
+// a simple library for booleans
+
+type UnitDynFn
+	def apply():Dyn
+
+type Bool
+	def ifTrue(trueCase:UnitDynFn, falseCase:UnitDynFn):Dyn
+
+val True : Bool = new
+	def ifTrue(trueCase:UnitDynFn, falseCase:UnitDynFn):Dyn
+		trueCase()
+	
+val False : Bool = new
+	def ifTrue(trueCase:UnitDynFn, falseCase:UnitDynFn):Dyn
+		falseCase()
+		
+// some test cases
+
+val cond : Bool = True
+val condf : Bool = False
+
+def launderAsInt(x:Int):Int = x
+
+//val two : Int = cond.ifTrue(() => 5, 2)
+val testFive : Int = cond.ifTrue(() => 5,() => 2)
+
+// only necessary because annotations on val/Let are ignored - TO DO
+val five : Int = testFive // launderAsInt(testFive)
+five

--- a/tools/src/wyvern/tools/tests/modules/module/example.wyv
+++ b/tools/src/wyvern/tools/tests/modules/module/example.wyv
@@ -1,4 +1,4 @@
-resource module A : sigA
-import D
+module def a() : A
+import modules.module.d
 val f : system.Int = 3
 def m(y : system.Int) : system.Int = y

--- a/tools/src/wyvern/tools/tests/modules/module/list.wyv
+++ b/tools/src/wyvern/tools/tests/modules/module/list.wyv
@@ -1,0 +1,39 @@
+type DynListToDynFn
+	def apply(element:Dyn,list:List):Dyn
+	
+type UnitDynFn
+	def apply():Dyn
+	
+resource type DynUnitFn
+	def apply(element:Dyn):Unit
+
+
+type List
+	def caseAnalyze(nilCase:UnitDynFn, consCase:DynListToDynFn):Dyn
+	def do(f:DynUnitFn):Unit
+
+def Cons(element:Dyn, tail:List):List = new
+	def caseAnalyze(nilCase:UnitDynFn, consCase:DynListToDynFn):Dyn
+		consCase(element, tail)
+	def do(f:DynUnitFn):Unit
+		f(element)
+		tail.do(f)
+
+val Nil = new
+	def caseAnalyze(nilCase:UnitDynFn, consCase:DynListToDynFn):Dyn
+		nilCase()
+	def do(f:DynUnitFn):Unit = new // return an empty object
+
+// some test cases
+
+val aList = Cons(1, Cons(2, Cons(5, Nil)))
+
+var count : Int = 0
+
+aList.do(x => count = x)
+
+def pickLast(list:List, seed:Int):Int
+	list.caseAnalyze(() => seed, (x,l) => pickLast(l,x))
+
+val five = pickLast(aList,0)
+five

--- a/tools/src/wyvern/tools/tests/modules/module/listClient.wyv
+++ b/tools/src/wyvern/tools/tests/modules/module/listClient.wyv
@@ -1,0 +1,15 @@
+import stdlib.collections.list
+
+// some test cases
+
+val aList = list.Cons(1, list.Cons(2, list.Cons(5, list.Nil)))
+
+var count : Int = 0
+
+aList.do(x => count = x)
+
+def pickLast(lst:list.List, seed:Int):Int
+	lst.caseAnalyze(() => seed, (x,l) => pickLast(l,x))
+
+val five = pickLast(aList,0)
+five

--- a/tools/src/wyvern/tools/tests/modules/module/main.wyv
+++ b/tools/src/wyvern/tools/tests/modules/module/main.wyv
@@ -1,4 +1,3 @@
-resource module main
-instantiate A() as copyA
-instantiate B(copyA) as copyB
+instantiate modules.module.one() as copyOfOne
+instantiate modules.module.two(copyOfOne) as copyOfTwo
 val x : Int = 3

--- a/tools/src/wyvern/tools/tests/modules/module/one.wyv
+++ b/tools/src/wyvern/tools/tests/modules/module/one.wyv
@@ -1,3 +1,3 @@
-resource module A : sigA
+module def one() : One
 val f : system.Int = 3
 def m(y : system.Int) : system.Int = y

--- a/tools/src/wyvern/tools/tests/modules/module/recursive.wyv
+++ b/tools/src/wyvern/tools/tests/modules/module/recursive.wyv
@@ -1,4 +1,3 @@
-resource module A : sigA
+module def a() : A
 val f : system.Int = 3
 def m(y : system.Int) : system.Int = m(y)
-

--- a/tools/src/wyvern/tools/tests/modules/module/three.wyv
+++ b/tools/src/wyvern/tools/tests/modules/module/three.wyv
@@ -1,2 +1,2 @@
-module D : signD
+module three : Three
 def m(y: system.Int) : system.Int = 42

--- a/tools/src/wyvern/tools/tests/modules/module/two.wyv
+++ b/tools/src/wyvern/tools/tests/modules/module/two.wyv
@@ -1,0 +1,3 @@
+module def b(objOne : modules.module.One) : Two
+import modules.module.three
+val k : system.Int = objOne.m(3)

--- a/tools/src/wyvern/tools/tests/modules/paper-module-example/DocumentLock.wyv
+++ b/tools/src/wyvern/tools/tests/modules/paper-module-example/DocumentLock.wyv
@@ -1,4 +1,0 @@
-resource module DocumentLock
-require UserInfo as uInfo
-def sign() : Bool
-  var signee : Str = uInfo.getName()

--- a/tools/src/wyvern/tools/tests/modules/paper-module-example/List.wyv
+++ b/tools/src/wyvern/tools/tests/modules/paper-module-example/List.wyv
@@ -1,4 +1,0 @@
-module List
-def add(v : Int) : Unit
-  value = v
-var value : Int = 42

--- a/tools/src/wyvern/tools/tests/modules/paper-module-example/Main.wyv
+++ b/tools/src/wyvern/tools/tests/modules/paper-module-example/Main.wyv
@@ -1,3 +1,0 @@
-resource module Main
-instantiate UserInfo as uInfo
-// instantiate DocumentLock(uInfo) as dl

--- a/tools/src/wyvern/tools/tests/modules/paper-module-example/UserInfo.wyv
+++ b/tools/src/wyvern/tools/tests/modules/paper-module-example/UserInfo.wyv
@@ -1,8 +1,0 @@
-resource module UserInfo
-import List
-var name : Str = "EMPTY"
-def init(uName : Name) : Unit
-  name = uName
-  actionHistory : List = new List
-def getName() : Str =
-  name

--- a/tools/src/wyvern/tools/tests/modules/parameterized.wyv
+++ b/tools/src/wyvern/tools/tests/modules/parameterized.wyv
@@ -1,5 +1,3 @@
-resource module parameterized
-
-require modules.Formal as formal
+module def parameterized(formal : modules.Formal)
 
 def getFive():Int = formal.f()

--- a/tools/src/wyvern/tools/tests/modules/pclient.wyv
+++ b/tools/src/wyvern/tools/tests/modules/pclient.wyv
@@ -1,7 +1,7 @@
-import modules.Actual
+import modules.actual
 import modules.parameterized
 
-val actual = Actual()
-val p = parameterized(actual)
+val a = actual()
+val p = parameterized(a)
 
 p.getFive()

--- a/tools/src/wyvern/tools/tests/modules/rsType.wyv
+++ b/tools/src/wyvern/tools/tests/modules/rsType.wyv
@@ -1,3 +1,3 @@
-resource module testModule
+module def testModule()
 resource type Log
 	def log(x:Str) : Unit

--- a/tools/src/wyvern/tools/tests/modules/sqlApplication.wyv
+++ b/tools/src/wyvern/tools/tests/modules/sqlApplication.wyv
@@ -1,10 +1,6 @@
-resource module sqlApplication
+module def sqlApplication(safeSQL : db.SafeSQL)
 
 //import db.stringSQL
-
-require db.SafeSQL as safeSQL
-
-
 
 def run() : Int
     val input = "CouldBeUnsafe"

--- a/tools/src/wyvern/tools/tests/modules/testModule.wyv
+++ b/tools/src/wyvern/tools/tests/modules/testModule.wyv
@@ -1,2 +1,2 @@
-resource module testModule
+module def testModule()
 val x : Str = "5"


### PR DESCRIPTION
* Changed the parser to work with the latest version of the module headers' syntax and to disallow 'require' inside modules
* Changed all the module-related test cases to use the new syntax (thus, the PR is quite large)
* Made capitalization of module names and files consistent:
  + module types are capitalized and don't have any '[Ss]ig' prefixes
  + module names are lowercase
  + .wyv file names are lowercase (as Git has trouble handling file renaming, name changes were handled as file deletion-creation pairs)
