### PR TITLE
DynCastsTransformer

### DIFF
--- a/tools/src/wyvern/target/corewyvernIL/expression/Cast.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/Cast.java
@@ -27,7 +27,7 @@ public class Cast extends Expression{
 	@Override
 	public ValueType typeCheck(TypeContext ctx) {
 		toCastExpr.typeCheck(ctx);
-		return getExprType();
+		return getExprType().getCanonicalType(ctx);
 	}
 
 	@Override

--- a/tools/src/wyvern/target/corewyvernIL/expression/Cast.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/Cast.java
@@ -1,5 +1,6 @@
 package wyvern.target.corewyvernIL.expression;
 
+import java.io.IOException;
 import java.util.Set;
 
 import wyvern.target.corewyvernIL.astvisitor.ASTVisitor;
@@ -49,4 +50,14 @@ public class Cast extends Expression{
 	public Set<String> getFreeVariables() {
 		return toCastExpr.getFreeVariables();
 	}
+	
+	@Override
+    public void doPrettyPrint(Appendable dest, String indent) throws IOException {
+	    dest.append("(");
+	    getExprType().doPrettyPrint(dest, "");
+	    dest.append(") ");
+	    this.toCastExpr.doPrettyPrint(dest, "");
+    }
+    
+	
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/Cast.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/Cast.java
@@ -53,10 +53,11 @@ public class Cast extends Expression{
 	
 	@Override
     public void doPrettyPrint(Appendable dest, String indent) throws IOException {
-	    dest.append("(");
+	    dest.append("((");
 	    getExprType().doPrettyPrint(dest, "");
 	    dest.append(") ");
-	    this.toCastExpr.doPrettyPrint(dest, "");
+	    toCastExpr.doPrettyPrint(dest, "");
+	    dest.append(")"); 
     }
     
 	

--- a/tools/src/wyvern/target/corewyvernIL/expression/FieldSet.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/FieldSet.java
@@ -50,11 +50,11 @@ public class FieldSet extends Expression {
 		if (objectExpr instanceof FieldGet) {
 			IExpr receiver = ((FieldGet)objectExpr).getObjectExpr();
 			receiverType = receiver.typeCheck(ctx);
-		}
-		else if (objectExpr instanceof Variable) {
+		} else if (objectExpr instanceof Variable) {
 			receiverType = ctx.lookupTypeOf(((Variable)objectExpr).getName());
+		} else {
+		    throw new RuntimeException("Target of FieldSet is unsupported. Type: " + objectExpr.getClass());
 		}
-		else throw new RuntimeException("Target of FieldSet is unsupported. Type: " + objectExpr.getClass());
 		return Util.isDynamicType(receiverType);
 	}
 	
@@ -64,7 +64,7 @@ public class FieldSet extends Expression {
 	    // Setting the field of a dynamic object.
 		if (settingDynamicObject(ctx)) {
 		    exprToAssign.typeCheck(ctx);
-		    return Util.dynType();
+		    return Util.unitType();
 		}
 		
 		// Figure out types of object and expression.

--- a/tools/src/wyvern/target/corewyvernIL/expression/FieldSet.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/FieldSet.java
@@ -52,9 +52,11 @@ public class FieldSet extends Expression {
 			receiverType = receiver.typeCheck(ctx);
 		} else if (objectExpr instanceof Variable) {
 			receiverType = ctx.lookupTypeOf(((Variable)objectExpr).getName());
+		} else if (objectExpr instanceof Cast) {
+		    receiverType = objectExpr.typeCheck(ctx);
 		} else {
 		    throw new RuntimeException("Target of FieldSet is unsupported. Type: " + objectExpr.getClass());
-		}
+	    }
 		return Util.isDynamicType(receiverType);
 	}
 	

--- a/tools/src/wyvern/tools/tests/TransformTests.java
+++ b/tools/src/wyvern/tools/tests/TransformTests.java
@@ -12,6 +12,7 @@ import wyvern.target.corewyvernIL.ASTNode;
 import wyvern.target.corewyvernIL.astvisitor.ASTVisitor;
 import wyvern.target.corewyvernIL.expression.IExpr;
 import wyvern.target.corewyvernIL.expression.IntegerLiteral;
+import wyvern.target.corewyvernIL.expression.StringLiteral;
 import wyvern.target.corewyvernIL.expression.Value;
 import wyvern.target.corewyvernIL.modules.TypedModuleSpec;
 import wyvern.target.corewyvernIL.support.EvalContext;
@@ -165,6 +166,26 @@ public class TransformTests {
 	    typecheck(program, Util.dynType());
 	    run(program, new IntegerLiteral(5));
 	    
+	}
+	
+	@Test
+	public void testUnsafeFieldAccess() throws ParseException {
+	    
+	    String input = "val obj: Dyn = new\n"
+	                 + "    val field: system.String = \"hello\"\n"
+	                 + "val x: system.Int = obj.field\n"
+	                 + "x";
+	    
+	    // Should compile and run OK without casts.
+	    IExpr program = compile(input);
+	    typecheck(program, Util.intType());
+	    run(program, new StringLiteral("hello"));
+	                 
+	    // Should through a runtime type-error with casts.
+	    program = compile(input, new DynCastsTransformer());
+	    typecheck(program, Util.intType());
+	    runWithToolError(program, ErrorMessage.NOT_SUBTYPE);    
+        
 	}
 	
 }

--- a/tools/src/wyvern/tools/tests/TransformTests.java
+++ b/tools/src/wyvern/tools/tests/TransformTests.java
@@ -18,6 +18,7 @@ import wyvern.target.corewyvernIL.support.EvalContext;
 import wyvern.target.corewyvernIL.support.GenContext;
 import wyvern.target.corewyvernIL.support.InterpreterState;
 import wyvern.target.corewyvernIL.support.TypeContext;
+import wyvern.target.corewyvernIL.support.Util;
 import wyvern.target.corewyvernIL.transformers.DynCastsTransformer;
 import wyvern.target.corewyvernIL.type.NominalType;
 import wyvern.target.corewyvernIL.type.ValueType;
@@ -132,20 +133,38 @@ public class TransformTests {
 	@Test
 	public void testUnsafeDynCasting () throws ParseException {
 		
-		String input = "val intToInt : Dyn = new\n"
+		String input = "val intToInt: Dyn = new\n"
 				     + "    def app():system.Int = 5\n\n"
-				     + "val anInt : system.Int = intToInt\n"
+				     + "val anInt: system.Int = intToInt\n"
 				     + "anInt";
 
 		// Should compile and run OK without casts.
 		IExpr program = compile(input);		
-		typecheck(program, new NominalType("system", "Int"));
+		typecheck(program, Util.intType());
 		
 		// But we should get a casting error, once we've added the casts.
 		program = compile(input, new DynCastsTransformer());
-		typecheck(program, new NominalType("system", "Int"));
+		typecheck(program, Util.intType());
 		runWithToolError(program, ErrorMessage.NOT_SUBTYPE);	
 		
+	}
+	
+	@Test
+	public void testSafeFieldAccess() throws ParseException {
+	    
+	    String input = "val obj: Dyn = new\n"
+	                 + "    val field: system.Int = 5\n"
+	                 + "obj.field\n";
+	    
+	    // Should compile and run OK without casts.
+	    IExpr program = compile(input);
+	    typecheck(program, Util.dynType());
+	    
+	    // Should compile and run OK with casts.
+	    program = compile(input, new DynCastsTransformer());
+	    typecheck(program, Util.dynType());
+	    run(program, new IntegerLiteral(5));
+	    
 	}
 	
 }


### PR DESCRIPTION
Addresses #87

* Update DynCastsTransformer so it will cast a dynamic receiver to the appropriate type in FieldSet/FieldGet/MethodCall expressions.
* Add a few tests to show the transformation works in some simple examples.
* Add a more complicated example involving nested resources which breaks under DynCastsTransformer--See the issue page for more.