### PR TITLE
Coreil modules

### DIFF
--- a/tools/src/wyvern/target/corewyvernIL/astvisitor/ASTVisitor.java
+++ b/tools/src/wyvern/target/corewyvernIL/astvisitor/ASTVisitor.java
@@ -4,6 +4,7 @@ import wyvern.target.corewyvernIL.Case;
 import wyvern.target.corewyvernIL.FormalArg;
 import wyvern.target.corewyvernIL.decl.DefDeclaration;
 import wyvern.target.corewyvernIL.decl.DelegateDeclaration;
+import wyvern.target.corewyvernIL.decl.ModuleDeclaration;
 import wyvern.target.corewyvernIL.decl.TypeDeclaration;
 import wyvern.target.corewyvernIL.decl.ValDeclaration;
 import wyvern.target.corewyvernIL.decl.VarDeclaration;
@@ -47,6 +48,7 @@ public abstract class ASTVisitor<S, T> {
 	public abstract T visit(S state, VarDeclaration varDecl);
 	public abstract T visit(S state, DefDeclaration defDecl);
 	public abstract T visit(S state, ValDeclaration valDecl);
+  public abstract T visit(S state, ModuleDeclaration moduleDecl);
 	public abstract T visit(S state, IntegerLiteral integerLiteral);
   public abstract T visit(S state, BooleanLiteral booleanLiteral);
 	public abstract T visit(S state, RationalLiteral rational);

--- a/tools/src/wyvern/target/corewyvernIL/astvisitor/EmitOIRVisitor.java
+++ b/tools/src/wyvern/target/corewyvernIL/astvisitor/EmitOIRVisitor.java
@@ -9,6 +9,7 @@ import wyvern.target.corewyvernIL.FormalArg;
 import wyvern.target.corewyvernIL.decl.Declaration;
 import wyvern.target.corewyvernIL.decl.DefDeclaration;
 import wyvern.target.corewyvernIL.decl.DelegateDeclaration;
+import wyvern.target.corewyvernIL.decl.ModuleDeclaration;
 import wyvern.target.corewyvernIL.decl.TypeDeclaration;
 import wyvern.target.corewyvernIL.decl.ValDeclaration;
 import wyvern.target.corewyvernIL.decl.VarDeclaration;
@@ -487,4 +488,9 @@ public class EmitOIRVisitor extends ASTVisitor<EmitOIRState, OIRAST> {
 	public OIRAST visit(EmitOIRState state, Case c) {
 		throw new RuntimeException("EMITOIRVisitor: Case -> OIR implemented inside the visit method for Match expressions.");
 	}
+
+    @Override
+    public OIRAST visit(EmitOIRState state, ModuleDeclaration modDecl) {
+        throw new RuntimeException("ModuleDeclarations should be specialized before emitting Python!");
+    }
 }

--- a/tools/src/wyvern/target/corewyvernIL/astvisitor/PlatformSpecializationVisitor.java
+++ b/tools/src/wyvern/target/corewyvernIL/astvisitor/PlatformSpecializationVisitor.java
@@ -68,7 +68,8 @@ public class PlatformSpecializationVisitor extends ASTVisitor<PSVState, ASTNode>
     public ASTNode visit(PSVState state, New newExpr) {
         ArrayList<Declaration> newDecls = new ArrayList<>();
         for (Declaration decl : newExpr.getDecls()) {
-            newDecls.add((Declaration)decl.acceptVisitor(this, state));
+            ASTNode result = decl.acceptVisitor(this, state);
+            newDecls.add((Declaration)result);
         }
         New result = new New(newDecls, newExpr.getSelfName(), newExpr.getExprType(), newExpr.getLocation());
         result.copyMetadata(newExpr);
@@ -76,7 +77,8 @@ public class PlatformSpecializationVisitor extends ASTVisitor<PSVState, ASTNode>
     }
 
     public ASTNode visit(PSVState state, Case c) {
-        Case result = (Case)c.getBody().acceptVisitor(this, state);
+        Expression resultBody = (Expression)c.getBody().acceptVisitor(this, state);
+        Case result = new Case(c.getVarName(), c.getPattern(), resultBody);
         result.copyMetadata(c);
         return result;
     }
@@ -109,7 +111,8 @@ public class PlatformSpecializationVisitor extends ASTVisitor<PSVState, ASTNode>
 
 
     public ASTNode visit(PSVState state, FieldGet fieldGet) {
-        FieldGet result = (FieldGet)fieldGet.getObjectExpr().acceptVisitor(this, state);
+        IExpr resultExpr = (IExpr)fieldGet.getObjectExpr().acceptVisitor(this, state);
+        FieldGet result = new FieldGet(resultExpr, fieldGet.getName(), fieldGet.getLocation());
         result.copyMetadata(fieldGet);
         return result;
     }
@@ -119,7 +122,7 @@ public class PlatformSpecializationVisitor extends ASTVisitor<PSVState, ASTNode>
         IExpr toReplace = (IExpr)let.getToReplace().acceptVisitor(this, state);
         IExpr inExpr = (IExpr)let.getInExpr().acceptVisitor(this, state);
 
-        Let result = new Let(let.getVarName(), let.getExprType(), toReplace, inExpr);
+        Let result = new Let(let.getVarName(), let.getVarType(), toReplace, inExpr);
         result.copyMetadata(let);
         return result;
     }
@@ -141,26 +144,30 @@ public class PlatformSpecializationVisitor extends ASTVisitor<PSVState, ASTNode>
 
 
     public ASTNode visit(PSVState state, Cast cast) {
-        Cast result = (Cast)cast.getToCastExpr().acceptVisitor(this, state);
+        IExpr resultExpr = (IExpr)cast.getToCastExpr().acceptVisitor(this, state);
+        Cast result = new Cast(resultExpr, cast.getExprType());
         result.copyMetadata(cast);
         return result;
     }
 
 
     public ASTNode visit(PSVState state, VarDeclaration varDecl) {
-        VarDeclaration result = (VarDeclaration)varDecl.getDefinition().acceptVisitor(this, state);
+        ASTNode resultDefinition = (ASTNode)varDecl.getDefinition().acceptVisitor(this, state);
+        VarDeclaration result = new VarDeclaration(varDecl.getName(), varDecl.getType(), (IExpr)resultDefinition, varDecl.getLocation());
         result.copyMetadata(varDecl);
         return result;
     }
 
     public ASTNode visit(PSVState state, DefDeclaration defDecl) {
-        ASTNode result = (ASTNode)defDecl.getBody().acceptVisitor(this, state);
+        ASTNode resultBody = (ASTNode)defDecl.getBody().acceptVisitor(this, state);
+        DefDeclaration result = new DefDeclaration(defDecl.getName(), defDecl.getFormalArgs(), defDecl.getType(), (IExpr)resultBody, defDecl.getLocation());
         result.copyMetadata(defDecl);
         return result;
     }
 
     public ASTNode visit(PSVState state, ValDeclaration valDecl) {
-        ValDeclaration result = (ValDeclaration)valDecl.getDefinition().acceptVisitor(this, state);
+        ASTNode resultDefinition = (ASTNode)valDecl.getDefinition().acceptVisitor(this, state);
+        ValDeclaration result = new ValDeclaration(valDecl.getName(), valDecl.getType(), (IExpr)resultDefinition, valDecl.getLocation());
         result.copyMetadata(valDecl);
         return result;
     }

--- a/tools/src/wyvern/target/corewyvernIL/astvisitor/PlatformSpecializationVisitor.java
+++ b/tools/src/wyvern/target/corewyvernIL/astvisitor/PlatformSpecializationVisitor.java
@@ -1,0 +1,286 @@
+package wyvern.target.corewyvernIL.astvisitor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Vector;
+
+import wyvern.target.corewyvernIL.ASTNode;
+import wyvern.target.corewyvernIL.Case;
+import wyvern.target.corewyvernIL.FormalArg;
+import wyvern.target.corewyvernIL.VarBinding;
+import wyvern.target.corewyvernIL.decl.Declaration;
+import wyvern.target.corewyvernIL.decl.DefDeclaration;
+import wyvern.target.corewyvernIL.decl.DelegateDeclaration;
+import wyvern.target.corewyvernIL.decl.ModuleDeclaration;
+import wyvern.target.corewyvernIL.decl.TypeDeclaration;
+import wyvern.target.corewyvernIL.decl.ValDeclaration;
+import wyvern.target.corewyvernIL.decl.VarDeclaration;
+import wyvern.target.corewyvernIL.decltype.AbstractTypeMember;
+import wyvern.target.corewyvernIL.decltype.ConcreteTypeMember;
+import wyvern.target.corewyvernIL.decltype.DeclType;
+import wyvern.target.corewyvernIL.decltype.DefDeclType;
+import wyvern.target.corewyvernIL.decltype.ValDeclType;
+import wyvern.target.corewyvernIL.decltype.VarDeclType;
+import wyvern.target.corewyvernIL.expression.Bind;
+import wyvern.target.corewyvernIL.expression.BooleanLiteral;
+import wyvern.target.corewyvernIL.expression.Cast;
+import wyvern.target.corewyvernIL.expression.Expression;
+import wyvern.target.corewyvernIL.expression.FFI;
+import wyvern.target.corewyvernIL.expression.FFIImport;
+import wyvern.target.corewyvernIL.expression.FieldGet;
+import wyvern.target.corewyvernIL.expression.FieldSet;
+import wyvern.target.corewyvernIL.expression.IExpr;
+import wyvern.target.corewyvernIL.expression.IntegerLiteral;
+import wyvern.target.corewyvernIL.expression.Let;
+import wyvern.target.corewyvernIL.expression.Match;
+import wyvern.target.corewyvernIL.expression.MethodCall;
+import wyvern.target.corewyvernIL.expression.New;
+import wyvern.target.corewyvernIL.expression.RationalLiteral;
+import wyvern.target.corewyvernIL.expression.StringLiteral;
+import wyvern.target.corewyvernIL.expression.Variable;
+import wyvern.target.corewyvernIL.support.GenContext;
+import wyvern.target.corewyvernIL.support.TypeContext;
+import wyvern.target.corewyvernIL.type.DataType;
+import wyvern.target.corewyvernIL.type.ExtensibleTagType;
+import wyvern.target.corewyvernIL.type.NominalType;
+import wyvern.target.corewyvernIL.type.StructuralType;
+import wyvern.target.corewyvernIL.type.ValueType;
+
+class PSVState {
+    public String platform;
+    public GenContext ctx;
+    public PSVState(String platform, GenContext ctx) {
+        this.platform = platform;
+        this.ctx = ctx;
+    }
+}
+
+public class PlatformSpecializationVisitor extends ASTVisitor<PSVState, ASTNode> {
+
+    public static ASTNode specializeAST(ASTNode ast, String platform, GenContext ctx) {
+        return ast.acceptVisitor(new PlatformSpecializationVisitor(), new PSVState(platform, ctx));
+    }
+
+    public ASTNode visit(PSVState state, ModuleDeclaration moduleDecl) {
+        return moduleDecl.specialize(state.platform, state.ctx);
+    }
+
+    public ASTNode visit(PSVState state, New newExpr) {
+        ArrayList<Declaration> newDecls = new ArrayList<>();
+        for (Declaration decl : newExpr.getDecls()) {
+            newDecls.add((Declaration)decl.acceptVisitor(this, state));
+        }
+        New result = new New(newDecls, newExpr.getSelfName(), newExpr.getExprType(), newExpr.getLocation());
+        result.copyMetadata(newExpr);
+        return result;
+    }
+
+    public ASTNode visit(PSVState state, Case c) {
+        Case result = (Case)c.getBody().acceptVisitor(this, state);
+        result.copyMetadata(c);
+        return result;
+    }
+
+    public ASTNode visit(PSVState state, MethodCall methodCall) {
+        IExpr objExpr = (IExpr)methodCall.getObjectExpr().acceptVisitor(this, state);
+        List<IExpr> args = new ArrayList<>();
+        for (IExpr arg : methodCall.getArgs()) {
+            args.add((IExpr)arg.acceptVisitor(this, state));
+        }
+
+        MethodCall result = new MethodCall(objExpr, methodCall.getMethodName(), args, methodCall);
+        result.copyMetadata(methodCall);
+        return result;
+    }
+
+
+    public ASTNode visit(PSVState state, Match match) {
+        Expression matchExpr = (Expression)match.getMatchExpr().acceptVisitor(this, state);
+        Expression elseExpr = (Expression)match.getElseExpr().acceptVisitor(this, state);
+        List<Case> cases = new ArrayList<Case>();
+        for (Case matchCase : match.getCases()) {
+            cases.add((Case)matchCase.getBody().acceptVisitor(this, state));
+        }
+
+        Match result = new Match(matchExpr, elseExpr, cases);
+        result.copyMetadata(match);
+        return result;
+    }
+
+
+    public ASTNode visit(PSVState state, FieldGet fieldGet) {
+        FieldGet result = (FieldGet)fieldGet.getObjectExpr().acceptVisitor(this, state);
+        result.copyMetadata(fieldGet);
+        return result;
+    }
+
+
+    public ASTNode visit(PSVState state, Let let) {
+        IExpr toReplace = (IExpr)let.getToReplace().acceptVisitor(this, state);
+        IExpr inExpr = (IExpr)let.getInExpr().acceptVisitor(this, state);
+
+        Let result = new Let(let.getVarName(), let.getExprType(), toReplace, inExpr);
+        result.copyMetadata(let);
+        return result;
+    }
+
+
+    public ASTNode visit(PSVState state, FieldSet fieldSet) {
+        IExpr objectExpr = (IExpr)fieldSet.getObjectExpr().acceptVisitor(this, state);
+        IExpr exprToAssign = (IExpr)fieldSet.getExprToAssign().acceptVisitor(this, state);
+
+        FieldSet result = new FieldSet(fieldSet.getExprType(), objectExpr, fieldSet.getFieldName(), exprToAssign);
+        result.copyMetadata(fieldSet);
+        return result;
+    }
+
+
+    public ASTNode visit(PSVState state, Variable variable) {
+        return variable;
+    }
+
+
+    public ASTNode visit(PSVState state, Cast cast) {
+        Cast result = (Cast)cast.getToCastExpr().acceptVisitor(this, state);
+        result.copyMetadata(cast);
+        return result;
+    }
+
+
+    public ASTNode visit(PSVState state, VarDeclaration varDecl) {
+        VarDeclaration result = (VarDeclaration)varDecl.getDefinition().acceptVisitor(this, state);
+        result.copyMetadata(varDecl);
+        return result;
+    }
+
+    public ASTNode visit(PSVState state, DefDeclaration defDecl) {
+        ASTNode result = (ASTNode)defDecl.getBody().acceptVisitor(this, state);
+        result.copyMetadata(defDecl);
+        return result;
+    }
+
+    public ASTNode visit(PSVState state, ValDeclaration valDecl) {
+        ValDeclaration result = (ValDeclaration)valDecl.getDefinition().acceptVisitor(this, state);
+        result.copyMetadata(valDecl);
+        return result;
+    }
+
+
+    public ASTNode visit(PSVState state,
+                         IntegerLiteral integerLiteral) {
+        return integerLiteral;
+    }
+
+
+    public ASTNode visit(PSVState state,
+                      BooleanLiteral booleanLiteral) {
+        return booleanLiteral;
+    }
+
+
+    public ASTNode visit(PSVState state,
+                         RationalLiteral rational) {
+        return rational;
+    }
+
+
+    public ASTNode visit(PSVState state,
+                         FormalArg formalArg) {
+        return formalArg;
+    }
+
+
+    public ASTNode visit(PSVState state,
+                         VarDeclType varDeclType) {
+        return varDeclType;
+    }
+
+    public ASTNode visit(PSVState state,
+                         ValDeclType valDeclType) {
+        return valDeclType;
+    }
+
+
+    public ASTNode visit(PSVState state,
+                         DefDeclType defDeclType) {
+        return defDeclType;
+    }
+
+
+    public ASTNode visit(PSVState state,
+                         AbstractTypeMember abstractDeclType) {
+        return abstractDeclType;
+    }
+
+    public ASTNode visit(PSVState state,
+                         StructuralType structuralType) {
+        return structuralType;
+    }
+
+    public ASTNode visit(PSVState state, NominalType nominalType) {
+        return nominalType;
+    }
+
+    public ASTNode visit(PSVState state, StringLiteral stringLiteral) {
+        return stringLiteral;
+    }
+
+    public ASTNode visit(PSVState state, DelegateDeclaration delegateDecl) {
+        return delegateDecl;
+    }
+
+    @Override
+    public ASTNode visit(PSVState state, Bind bind) {
+        List<VarBinding> bindings = new ArrayList<>();
+        for (VarBinding binding : bind.getBindings()) {
+            bindings.add(new VarBinding(binding.getVarName(),
+                                        binding.getType(),
+                                        (IExpr)binding.getExpression().acceptVisitor(this, state)));
+        }
+        IExpr inExpr = (IExpr)bind.getInExpr().acceptVisitor(this, state);
+
+        Bind result = new Bind(bindings, inExpr);
+        result.copyMetadata(bind);
+        return result;
+    }
+
+    @Override
+    public ASTNode visit(PSVState state,
+                         ConcreteTypeMember concreteTypeMember) {
+        return concreteTypeMember;
+    }
+
+    @Override
+    public ASTNode visit(PSVState state,
+                         TypeDeclaration typeDecl) {
+        return typeDecl;
+    }
+
+    @Override
+    public ASTNode visit(PSVState state,
+    		ValueType caseType) {
+        return caseType;
+    }
+
+    @Override
+    public ASTNode visit(PSVState state,
+                         ExtensibleTagType extensibleTagType) {
+        return extensibleTagType;
+    }
+
+    @Override
+    public ASTNode visit(PSVState state,
+                         DataType dataType) {
+        return dataType;
+    }
+
+    @Override
+    public ASTNode visit(PSVState state, FFIImport ffiImport) {
+        return ffiImport;
+    }
+
+    @Override
+    public ASTNode visit(PSVState state, FFI ffi) {
+        return ffi;
+    }
+}

--- a/tools/src/wyvern/target/corewyvernIL/astvisitor/TailCallVisitor.java
+++ b/tools/src/wyvern/target/corewyvernIL/astvisitor/TailCallVisitor.java
@@ -8,6 +8,7 @@ import wyvern.target.corewyvernIL.binding.Binding;
 import wyvern.target.corewyvernIL.decl.Declaration;
 import wyvern.target.corewyvernIL.decl.DefDeclaration;
 import wyvern.target.corewyvernIL.decl.DelegateDeclaration;
+import wyvern.target.corewyvernIL.decl.ModuleDeclaration;
 import wyvern.target.corewyvernIL.decl.TypeDeclaration;
 import wyvern.target.corewyvernIL.decl.ValDeclaration;
 import wyvern.target.corewyvernIL.decl.VarDeclaration;
@@ -246,6 +247,12 @@ public class TailCallVisitor extends ASTVisitor<Boolean, Void> {
 
     @Override
     public Void visit(Boolean inTailPosition, FFI ffi) {
+        return null;
+    }
+
+    @Override
+    public Void visit(Boolean inTailPosition, ModuleDeclaration moduleDecl) {
+        ((DefDeclaration)moduleDecl).acceptVisitor(this, inTailPosition);
         return null;
     }
 

--- a/tools/src/wyvern/target/corewyvernIL/decl/ModuleDeclaration.java
+++ b/tools/src/wyvern/target/corewyvernIL/decl/ModuleDeclaration.java
@@ -1,0 +1,32 @@
+package wyvern.target.corewyvernIL.decl;
+
+import java.util.List;
+
+import wyvern.target.corewyvernIL.FormalArg;
+import wyvern.target.corewyvernIL.expression.IExpr;
+import wyvern.target.corewyvernIL.modules.TypedModuleSpec;
+import wyvern.target.corewyvernIL.support.ModuleResolver;
+import wyvern.target.corewyvernIL.type.ValueType;
+import wyvern.tools.errors.FileLocation;
+
+
+public class ModuleDeclaration extends DefDeclaration {
+    private List<TypedModuleSpec> dependencies; // The list of platform-dependent modules we depend on
+
+    public ModuleDeclaration(String moduleName, List<FormalArg> formalArgs, ValueType type, IExpr body,
+                             List<TypedModuleSpec> dependencies, FileLocation loc) {
+        super(moduleName, formalArgs, type, body, loc);
+        this.dependencies = dependencies;
+    }
+
+    public Declaration specialize(String platform) {
+        ModuleResolver interpResolver = ModuleResolver.getLocal();
+        ModuleResolver resolver = new ModuleResolver(platform, interpResolver.getRootDir(), interpResolver.getLibDir());
+        IExpr body = resolver.wrap(getBody(), dependencies);
+
+        if (getFormalArgs().isEmpty())
+            return new ValDeclaration(getName(), getType(), body, getLocation());
+        else
+            return new DefDeclaration(getName(), getFormalArgs(), getType(), body, getLocation());
+    }
+}

--- a/tools/src/wyvern/target/corewyvernIL/decl/ModuleDeclaration.java
+++ b/tools/src/wyvern/target/corewyvernIL/decl/ModuleDeclaration.java
@@ -1,28 +1,41 @@
 package wyvern.target.corewyvernIL.decl;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import wyvern.target.corewyvernIL.FormalArg;
+import wyvern.target.corewyvernIL.VarBinding;
 import wyvern.target.corewyvernIL.expression.IExpr;
+import wyvern.target.corewyvernIL.expression.Let;
 import wyvern.target.corewyvernIL.modules.TypedModuleSpec;
+import wyvern.target.corewyvernIL.support.GenContext;
 import wyvern.target.corewyvernIL.support.ModuleResolver;
 import wyvern.target.corewyvernIL.type.ValueType;
 import wyvern.tools.errors.FileLocation;
+import wyvern.tools.typedAST.core.declarations.ImportDeclaration;
+import wyvern.tools.util.Pair;
 
 
 public class ModuleDeclaration extends DefDeclaration {
-    private List<TypedModuleSpec> dependencies; // The list of platform-dependent modules we depend on
+    private List<ImportDeclaration> dependencies; // The list of platform-dependent modules we depend on
 
     public ModuleDeclaration(String moduleName, List<FormalArg> formalArgs, ValueType type, IExpr body,
-                             List<TypedModuleSpec> dependencies, FileLocation loc) {
+                             List<ImportDeclaration> dependencies, FileLocation loc) {
         super(moduleName, formalArgs, type, body, loc);
         this.dependencies = dependencies;
     }
 
-    public Declaration specialize(String platform) {
+    public Declaration specialize(String platform, GenContext ctx) {
         ModuleResolver interpResolver = ModuleResolver.getLocal();
         ModuleResolver resolver = new ModuleResolver(platform, interpResolver.getRootDir(), interpResolver.getLibDir());
-        IExpr body = resolver.wrap(getBody(), dependencies);
+
+        IExpr body = getBody();
+        for (ImportDeclaration decl : dependencies) {
+            List<TypedModuleSpec> recursiveDependencies = new ArrayList<>();
+            Pair<VarBinding, GenContext> pair = decl.genBinding(resolver, ctx, recursiveDependencies);
+            body = new Let(pair.first, body);
+            body = resolver.wrap(body, recursiveDependencies);
+        }
 
         if (getFormalArgs().isEmpty())
             return new ValDeclaration(getName(), getType(), body, getLocation());

--- a/tools/src/wyvern/target/corewyvernIL/expression/Bind.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/Bind.java
@@ -26,6 +26,10 @@ public class Bind extends Expression {
 		this.inExpr = inExpr;
 	}
 
+    public List<VarBinding> getBindings() {
+        return bindings;
+    }
+
 	public List<String> getVarNames() {
 		List<String> varNames = new ArrayList<String>();
 		for (VarBinding vb : bindings) {

--- a/tools/src/wyvern/target/corewyvernIL/expression/Let.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/Let.java
@@ -23,6 +23,8 @@ public class Let extends Expression {
 	public Let(VarBinding binding, IExpr inExpr) {
 		super();
 		this.binding = binding;
+    if (this.getVarType() == null)
+        throw new RuntimeException("Let created with null variable type");
 		if (inExpr == null) throw new RuntimeException();
 		this.inExpr = inExpr;
 	}

--- a/tools/src/wyvern/target/corewyvernIL/support/ModuleResolver.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/ModuleResolver.java
@@ -140,7 +140,7 @@ public class ModuleResolver {
 	 * @param qualifiedName
 	 * @return
 	 */
-	private File resolve(String qualifiedName, boolean isType) {
+	public File resolve(String qualifiedName, boolean isType) {
 		String names[] = qualifiedName.split("\\.");
 		if (names.length == 0)
 			throw new RuntimeException();

--- a/tools/src/wyvern/target/corewyvernIL/support/ModuleResolver.java
+++ b/tools/src/wyvern/target/corewyvernIL/support/ModuleResolver.java
@@ -48,9 +48,13 @@ public class ModuleResolver {
     private String platform;
 	private Map<String, Module> moduleCache = new HashMap<String, Module>();
 	private InterpreterState state;
+    private File rootDir;
+    private File libDir;
 	
     public ModuleResolver(String platform, File rootDir, File libDir) {
     	this.platform = platform;
+        this.rootDir = rootDir;
+        this.libDir = libDir;
         ArrayList<File> searchPath = new ArrayList<File>();
         if (rootDir != null && !rootDir.isDirectory())
             throw new RuntimeException("the root path \""+rootDir+"\" for the module resolver must be a directory");
@@ -293,4 +297,12 @@ public class ModuleResolver {
 	public String getPlatform() {
 		return platform;
 	}
+
+    public File getRootDir() {
+        return rootDir;
+    }
+
+    public File getLibDir() {
+        return libDir;
+    }
 }

--- a/tools/src/wyvern/target/corewyvernIL/transformers/DynCastsTransformer.java
+++ b/tools/src/wyvern/target/corewyvernIL/transformers/DynCastsTransformer.java
@@ -9,6 +9,7 @@ import wyvern.target.corewyvernIL.astvisitor.ASTVisitor;
 import wyvern.target.corewyvernIL.decl.Declaration;
 import wyvern.target.corewyvernIL.decl.DefDeclaration;
 import wyvern.target.corewyvernIL.decl.DelegateDeclaration;
+import wyvern.target.corewyvernIL.decl.ModuleDeclaration;
 import wyvern.target.corewyvernIL.decl.TypeDeclaration;
 import wyvern.target.corewyvernIL.decl.ValDeclaration;
 import wyvern.target.corewyvernIL.decl.VarDeclaration;
@@ -250,6 +251,11 @@ public class DynCastsTransformer extends ASTVisitor<TypeContext, ASTNode> {
 		return new DefDeclaration(defDecl.getName(), defDecl.getFormalArgs(), defDecl.getType(),
 				bodyTransformed, defDecl.getLocation());
 	}
+
+    @Override
+    public ModuleDeclaration visit(TypeContext ctx, ModuleDeclaration moduleDecl) {
+        return (ModuleDeclaration)((DefDeclaration)moduleDecl).acceptVisitor(this, ctx);
+    }
 
 	@Override
 	public ValDeclaration visit(TypeContext ctx, ValDeclaration valDecl) {

--- a/tools/src/wyvern/tools/PythonCompiler.java
+++ b/tools/src/wyvern/tools/PythonCompiler.java
@@ -9,8 +9,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import wyvern.stdlib.Globals;
+import wyvern.target.corewyvernIL.ASTNode;
 import wyvern.target.corewyvernIL.astvisitor.EmitOIRVisitor;
 import wyvern.target.corewyvernIL.astvisitor.EmitOIRState;
+import wyvern.target.corewyvernIL.astvisitor.PlatformSpecializationVisitor;
 import wyvern.target.corewyvernIL.astvisitor.TailCallVisitor;
 import wyvern.target.corewyvernIL.expression.IExpr;
 import wyvern.target.corewyvernIL.modules.Module;
@@ -107,6 +109,7 @@ public class PythonCompiler {
       Module m = state.getResolver().load("unknown", filepath.toFile());
       IExpr program = m.getExpression();
       program = state.getResolver().wrap(program, m.getDependencies());
+      program = (IExpr)PlatformSpecializationVisitor.specializeAST((ASTNode)program, "python", Globals.getGenContext(state));
       TailCallVisitor.annotate(program);
 
       if (display_IL) {

--- a/tools/src/wyvern/tools/tests/ExampleTests.java
+++ b/tools/src/wyvern/tools/tests/ExampleTests.java
@@ -60,12 +60,12 @@ public class ExampleTests {
 		TestUtil.doTestScriptModularly(PATH, "xplatform.hello-explicit-writer", Util.unitType(), Util.unitValue());
 	}
 	
-	// @Test
-	// public void testPythonCompilerOnScript() {
-	// 	String[] args = new String[] { TestUtil.EXAMPLES_PATH + "pong/pong.wyv" };
-	// 	PythonCompiler.wyvernHome.set("..");
-	// 	PythonCompiler.wyvernRoot.set(TestUtil.EXAMPLES_PATH + "pong/");
-	// 	PythonCompiler.main(args);
-	// }
+	@Test
+	public void testPythonCompilerOnScript() {
+		String[] args = new String[] { TestUtil.EXAMPLES_PATH + "pong/pong.wyv" };
+		PythonCompiler.wyvernHome.set("..");
+		PythonCompiler.wyvernRoot.set(TestUtil.EXAMPLES_PATH + "pong/");
+		PythonCompiler.main(args);
+	}
 	
 }

--- a/tools/src/wyvern/tools/tests/ExampleTests.java
+++ b/tools/src/wyvern/tools/tests/ExampleTests.java
@@ -60,12 +60,12 @@ public class ExampleTests {
 		TestUtil.doTestScriptModularly(PATH, "xplatform.hello-explicit-writer", Util.unitType(), Util.unitValue());
 	}
 	
-	@Test
-	public void testPythonCompilerOnScript() {
-		String[] args = new String[] { TestUtil.EXAMPLES_PATH + "pong/pong.wyv" };
-		PythonCompiler.wyvernHome.set("..");
-		PythonCompiler.wyvernRoot.set(TestUtil.EXAMPLES_PATH + "pong/");
-		PythonCompiler.main(args);
-	}
+	// @Test
+	// public void testPythonCompilerOnScript() {
+	// 	String[] args = new String[] { TestUtil.EXAMPLES_PATH + "pong/pong.wyv" };
+	// 	PythonCompiler.wyvernHome.set("..");
+	// 	PythonCompiler.wyvernRoot.set(TestUtil.EXAMPLES_PATH + "pong/");
+	// 	PythonCompiler.main(args);
+	// }
 	
 }

--- a/tools/src/wyvern/tools/typedAST/core/declarations/ModuleDeclaration.java
+++ b/tools/src/wyvern/tools/typedAST/core/declarations/ModuleDeclaration.java
@@ -423,24 +423,10 @@ public class ModuleDeclaration extends Declaration implements CoreAST {
 		for(FormalArg arg : formalArgs) {
 			methodContext = methodContext.extend(arg.getName(), new Variable(arg.getName()), arg.getType());
 		}
-	    /* importing modules and instantiations are translated into let sentence */
+    /* importing modules and instantiations are translated into let sentence */
 		// Note: must wrap methodContext with platformDependent types first, or we will be unable to access platform-dependent imports
-		Iterator<TypedAST> it = platformDependentSeq.iterator();
-        ModuleResolver resolver = ModuleResolver.getLocal();
-		// while (it.hasNext()) {
-		// 	TypedAST dependency = it.next();
-		// 	if (dependency instanceof ImportDeclaration) {
-          
-        //     } else if (dependency instanceof Instantiation) {
-          
-        //     } else {
-        //         throw new RuntimeException("Unknown platform dependent object: " + dependency.toString());
-        //     }
-		// }
-		wyvern.target.corewyvernIL.expression.IExpr body = wrapLet(impInstSeq, normalSeq, methodContext, dependencies);
-        //GenContext ctx2 = wrapLetCtxWithIterator(platformDependentSeq.iterator(), normalSeq, methodContext, dependencies).second;
-        System.out.println("methodContext: " + methodContext.toString());
-        //System.out.println("ctx2: " + ctx2.toString());
+    GenContext ctxWithPlatDeps = wrapLetCtxWithIterator(platformDependentSeq.iterator(), new Sequence(), methodContext, dependencies).second;
+		wyvern.target.corewyvernIL.expression.IExpr body = wrapLet(impInstSeq, normalSeq, ctxWithPlatDeps, dependencies);
 		TypeContext tempContext = methodContext.getInterpreterState().getResolver().extendContext(methodContext, dependencies);
 		wyvern.target.corewyvernIL.type.ValueType returnType = body.typeCheck(tempContext);
 

--- a/tools/src/wyvern/tools/typedAST/core/declarations/ModuleDeclaration.java
+++ b/tools/src/wyvern/tools/typedAST/core/declarations/ModuleDeclaration.java
@@ -224,7 +224,7 @@ public class ModuleDeclaration extends Declaration implements CoreAST {
 
 
 	/**
-	 * @see wraoLetWithIterator
+	 * @see wrapLetWithIterator
 	 *
 	 * @param impInstSeq the sequence of import and instantiate
 	 * @param normalSeq the rest sequence

--- a/tools/src/wyvern/tools/typedAST/core/declarations/ModuleDeclaration.java
+++ b/tools/src/wyvern/tools/typedAST/core/declarations/ModuleDeclaration.java
@@ -356,11 +356,11 @@ public class ModuleDeclaration extends Declaration implements CoreAST {
                 Instantiation decl = (Instantiation)d;
                 uri = decl.getUri();
             }
-            if (uri == null) {
+            if (uri == null || !uri.getScheme().equals("wyv")) {
                 platformIndependent = Sequence.append(platformIndependent, d);
             } else {
-                System.out.println("Looking up URI path " + uri.getPath());
-                File f = ModuleResolver.getLocal().resolve(uri.getPath(), false);
+                System.out.println("Looking up URI path " + uri.getSchemeSpecificPart());
+                File f = ModuleResolver.getLocal().resolve(uri.getSchemeSpecificPart(), false);
                 if (isPlatformPath(ModuleResolver.getLocal().getPlatform(), f.getAbsolutePath()))
                     platformDependent = Sequence.append(platformDependent, d);
                 else


### PR DESCRIPTION
This is the initial implementation of modules inside the core Wyvern IL.
If M is a module that imports some other platform-dependent module, then M will compile to a ModuleDeclaration in the core IL, rather than a DefDeclaration or a ValDeclaration as before. 
This ModuleDeclaration should be platform-independent.
Then the PlatformSpecializationVisitor takes in a platform and links the ModuleDeclarations with the dependencies on the given platform, and the ModuleDeclarations become DefDeclarations or ValDeclarations.
From this point, compilation proceeds as before.