### PR TITLE
Make paths in TestUtil relative to WYVERN_HOME

### DIFF
--- a/tools/src/wyvern/tools/tests/TestUtil.java
+++ b/tools/src/wyvern/tools/tests/TestUtil.java
@@ -43,10 +43,12 @@ import wyvern.target.corewyvernIL.expression.Value;
 import wyvern.tools.types.Type;
 
 public class TestUtil {
-	public static final String BASE_PATH = "src/wyvern/tools/tests/";
+	public static final String WYVERN_HOME = System.getenv("WYVERN_HOME");
+	public static final String BASE_PATH = WYVERN_HOME == null
+										   ? "src/wyvern/tools/tests/" : WYVERN_HOME + "/tools/src/wyvern/tools/tests/";
 	public static final String STDLIB_PATH = BASE_PATH + "stdlib/";
-	public static final String LIB_PATH = "../stdlib/";
-	public static final String EXAMPLES_PATH = "../examples/";
+	public static final String LIB_PATH = WYVERN_HOME == null ? "../stdlib/" : WYVERN_HOME + "/stdlib/";
+	public static final String EXAMPLES_PATH = WYVERN_HOME == null ? "../examples/" : WYVERN_HOME + "/examples/";
 	private static final String PLATFORM_PATH = BASE_PATH + "platform/java/stdlib/";
 	
 	/** Sets up the standard library and platform paths in the Wyvern resolver


### PR DESCRIPTION
	When trying to run the examples/tsls/postfixClient.wyv file from the command prompt
	set to examples as the current directory, we were getting the following exception:

	Exception in thread "main" java.lang.RuntimeException: the root path "src/wyvern/tools/tests/" for the module resolver must be a directory

	This is a fix for this exception.