### PR TITLE
Includes the ILTests.testNestedDecl() test again since it now works

### DIFF
--- a/tools/src/wyvern/tools/tests/ILTests.java
+++ b/tools/src/wyvern/tools/tests/ILTests.java
@@ -1107,14 +1107,8 @@ public class ILTests {
         TestUtil.doTest(source, null, new IntegerLiteral(3));
     }
 
-    // TODO: the "right fix" for this bug is to allow an expression at the top level to refer
-    // to the type of a variable in scope.  In other words, top-level expressions shouldn't
-    // be turned into let expressions whose type must be interpretable without the bindings
-    // above.
     @Test
-    @Category(CurrentlyBroken.class)
     public void testNestedDecl() throws ParseException {
-
         String source = ""
                 + "type Body (body) => \n"
                 + "    type T \n"


### PR DESCRIPTION
As of commit 4447baf0824558f4ae76dc6c3e43a7fd5ca2d473, the ILTests.testNestedDecl() works. Removed the "CurrentlyBroken" annotation to include the test into the regression test suite.

After this PR is accepted, https://github.com/wyvernlang/wyvern/issues/135 can be closed.