### PR TITLE
Simple algebraic datatype implementation

### DIFF
--- a/tools/src/wyvern/target/corewyvernIL/astvisitor/PlatformSpecializationVisitor.java
+++ b/tools/src/wyvern/target/corewyvernIL/astvisitor/PlatformSpecializationVisitor.java
@@ -146,10 +146,11 @@ public class PlatformSpecializationVisitor extends ASTVisitor<PSVState, ASTNode>
 
     public ASTNode visit(PSVState state, Match match) {
         Expression matchExpr = (Expression) match.getMatchExpr().acceptVisitor(this, state);
-        Expression elseExpr = (Expression) match.getElseExpr().acceptVisitor(this, state);
+        Expression elseExpr = match.getElseExpr();
+        elseExpr =  elseExpr == null ? null : (Expression) elseExpr.acceptVisitor(this, state);
         List<Case> cases = new ArrayList<Case>();
         for (Case matchCase : match.getCases()) {
-            cases.add((Case) matchCase.getBody().acceptVisitor(this, state));
+            cases.add((Case) matchCase.acceptVisitor(this, state));
         }
 
         Match result = new Match(matchExpr, elseExpr, cases);

--- a/tools/src/wyvern/target/corewyvernIL/astvisitor/TailCallVisitor.java
+++ b/tools/src/wyvern/target/corewyvernIL/astvisitor/TailCallVisitor.java
@@ -22,6 +22,7 @@ import wyvern.target.corewyvernIL.decltype.VarDeclType;
 import wyvern.target.corewyvernIL.expression.Bind;
 import wyvern.target.corewyvernIL.expression.BooleanLiteral;
 import wyvern.target.corewyvernIL.expression.Cast;
+import wyvern.target.corewyvernIL.expression.Expression;
 import wyvern.target.corewyvernIL.expression.FFI;
 import wyvern.target.corewyvernIL.expression.FFIImport;
 import wyvern.target.corewyvernIL.expression.FieldGet;
@@ -82,7 +83,10 @@ public class TailCallVisitor extends ASTVisitor<Boolean, Void> {
 
     public Void visit(Boolean inTailPosition, Match match) {
         match.getMatchExpr().acceptVisitor(this, false);
-        match.getElseExpr().acceptVisitor(this, inTailPosition);
+        Expression elseExpr = match.getElseExpr();
+        if (elseExpr != null) {
+            elseExpr.acceptVisitor(this, inTailPosition);
+        }
         for (Case matchCase : match.getCases()) {
             matchCase.getBody().acceptVisitor(this, inTailPosition);
         }

--- a/tools/src/wyvern/target/corewyvernIL/decl/DefDeclaration.java
+++ b/tools/src/wyvern/target/corewyvernIL/decl/DefDeclaration.java
@@ -129,7 +129,7 @@ public class DefDeclaration extends NamedDeclaration {
         }
 
         FailureReason r = new FailureReason();
-        if (!bodyType.isSubtypeOf(getType(), methodCtx, r)) {
+        if (bodyType != null && !bodyType.isSubtypeOf(getType(), methodCtx, r)) {
             // for debugging
             ValueType resultType = getType();
             bodyType.isSubtypeOf(resultType, methodCtx, r);

--- a/tools/src/wyvern/target/corewyvernIL/decl/TypeDeclaration.java
+++ b/tools/src/wyvern/target/corewyvernIL/decl/TypeDeclaration.java
@@ -66,7 +66,7 @@ public class TypeDeclaration extends NamedDeclaration {
      */
     @Override
     public DeclType getDeclType() {
-        return new ConcreteTypeMember(getName(), (ValueType) sourceType, this.metadata);
+        return new ConcreteTypeMember(getName(), (ValueType) (sourceType.getValueType()), this.metadata);
     }
 
 }

--- a/tools/src/wyvern/target/corewyvernIL/decltype/DeclTypeWithResult.java
+++ b/tools/src/wyvern/target/corewyvernIL/decltype/DeclTypeWithResult.java
@@ -2,6 +2,7 @@ package wyvern.target.corewyvernIL.decltype;
 
 import wyvern.target.corewyvernIL.support.TypeContext;
 import wyvern.target.corewyvernIL.support.View;
+import wyvern.target.corewyvernIL.type.DataType;
 import wyvern.target.corewyvernIL.type.Type;
 import wyvern.target.corewyvernIL.type.ValueType;
 
@@ -13,15 +14,20 @@ public abstract class DeclTypeWithResult extends DeclType {
         this.rawType = sourceType;
     }
 
-    public ValueType getResultType(View v) {
-        //TODO: this is a hack, fix it
-        return ((ValueType) rawType).adapt(v);
-    }
-
     public ValueType getRawResultType() {
         //TODO: this is a hack, fix it
-        return (ValueType) rawType;
+        if (rawType instanceof DataType) {
+            DataType dt = (DataType) rawType;
+            return dt.getValueType();
+        } else {
+            return ((ValueType) rawType);
+        }
     }
+
+    public ValueType getResultType(View v) {
+        return getRawResultType().adapt(v);
+    }
+
 
     @Override
     public void checkWellFormed(TypeContext ctx) {

--- a/tools/src/wyvern/target/corewyvernIL/type/RefinementType.java
+++ b/tools/src/wyvern/target/corewyvernIL/type/RefinementType.java
@@ -129,7 +129,11 @@ public class RefinementType extends ValueType {
         }
         if (current != max) {
             // TODO: replace with a nice warning
-            throw new RuntimeException("invalid refinement type " + this);
+            // throw new RuntimeException("invalid refinement type " + this);
+
+            // this RefinementType was created by "new", therefore just use
+            // all the DeclTypes from the RefinementType and none from the base
+            newDTs = getDeclTypes(ctx);
         }
 
         return new StructuralType(baseST.getSelfName(), newDTs, isResource(ctx));

--- a/tools/src/wyvern/tools/errors/ErrorMessage.java
+++ b/tools/src/wyvern/tools/errors/ErrorMessage.java
@@ -79,6 +79,7 @@ public enum ErrorMessage {
     UNBOUNDED_WITHOUT_DEFAULT("Default must be present when matching over unbounded tag", 0),
     UNMATCHABLE_CASE("A variable of tag-type %ARG cannot possibly match against case %ARG", 2),
     MATCH_NO_COMMON_RETURN("Match statement does not have a common return type", 0),
+    UNMATCHED_CASE("Matched expression %ARG has no matching case", 1),
 
     // Evaluation errors
     VALUE_CANNOT_BE_APPLIED("The value %ARG cannot be applied to an argument", 1),

--- a/tools/src/wyvern/tools/tests/ILTests.java
+++ b/tools/src/wyvern/tools/tests/ILTests.java
@@ -618,6 +618,18 @@ public class ILTests {
         TestUtil.doTestScriptModularly("modules.module.operator-plus", Util.intType(), new IntegerLiteral(5));
     }
 
+
+    @Test
+    public void testTaggedList() throws ParseException {
+        TestUtil.doTestScriptModularly("modules.module.taggedList", Util.intType(), Util.intValue(0));
+    }
+
+    @Test
+    @Category(CurrentlyBroken.class)
+    public void testParametrizedTaggedList() throws ParseException {
+        TestUtil.doTestScriptModularly("modules.module.parametrizedList", Util.intType(), Util.intValue(0));
+    }
+
     @Test
     public void testJavaImport2() throws ParseException {
         String input = "module def main(java : Java)\n\n"

--- a/tools/src/wyvern/tools/tests/modules/module/lambdaCalc.wyv
+++ b/tools/src/wyvern/tools/tests/modules/module/lambdaCalc.wyv
@@ -1,0 +1,14 @@
+tagged type Exp comprises Var, Apply, Lambda, Unit
+
+tagged type Var extends Exp
+	val name : String
+
+tagged type Apply extends Exp
+	val fn : Exp
+	val arg: Exp
+	
+tagged type Lambda extends Exp
+	val param : String
+	val body : Exp
+
+tagged type Unit extends Exp

--- a/tools/src/wyvern/tools/tests/modules/module/parametrizedList.wyv
+++ b/tools/src/wyvern/tools/tests/modules/module/parametrizedList.wyv
@@ -1,0 +1,26 @@
+tagged type List comprises Cons, Nil
+	type T
+	val length:system.Int
+    
+tagged type Cons extends List
+	type T
+	val value:this.T
+	val next:List[this.T]
+	val length:system.Int
+    
+tagged type Nil extends List
+	type T
+	val length:system.Int
+
+def head(list:List[system.Int]):system.Int
+	match list:
+		c:Cons[system.Int] => c.value
+		n:Nil[system.Int] => 0
+
+val x : Nil[system.Int] = new
+	type T = system.Int
+	val length = 0
+	
+val h = head(x)
+
+h

--- a/tools/src/wyvern/tools/tests/modules/module/taggedList.wyv
+++ b/tools/src/wyvern/tools/tests/modules/module/taggedList.wyv
@@ -1,0 +1,22 @@
+tagged type List comprises Cons, Nil
+	val length:system.Int
+    
+tagged type Cons extends List
+    val value:system.Int
+    val next:List
+    val length:system.Int
+    
+tagged type Nil extends List
+	val length:system.Int
+
+def head(list:List):system.Int
+	match list:
+		c:Cons => c.value
+		n:Nil => 0
+
+val x : Nil = new
+	val length = 0
+	
+val h = head(x)
+
+h

--- a/tools/src/wyvern/tools/typedAST/core/declarations/TypeDeclaration.java
+++ b/tools/src/wyvern/tools/typedAST/core/declarations/TypeDeclaration.java
@@ -22,15 +22,21 @@ import wyvern.tools.typedAST.interfaces.CoreAST;
 public class TypeDeclaration extends AbstractTypeDeclaration implements CoreAST {
     private String name;
     private DeclSequence decls;
+    private TaggedInfo taggedInfo;
 
     public TypeDeclaration(String name, DeclSequence decls, TaggedInfo taggedInfo, FileLocation clsNameLine) {
         this.name = name;
         this.decls = decls;
         this.location = clsNameLine;
+        this.taggedInfo = taggedInfo;
     }
 
     public DeclSequence getDecls() {
         return decls;
+    }
+
+    public TaggedInfo getTaggedInfo() {
+        return taggedInfo;
     }
 
     private FileLocation location = FileLocation.UNKNOWN;

--- a/tools/src/wyvern/tools/typedAST/core/expressions/Match.java
+++ b/tools/src/wyvern/tools/typedAST/core/expressions/Match.java
@@ -2,15 +2,20 @@ package wyvern.tools.typedAST.core.expressions;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import wyvern.target.corewyvernIL.expression.Expression;
+import wyvern.target.corewyvernIL.expression.IExpr;
 import wyvern.target.corewyvernIL.modules.TypedModuleSpec;
 import wyvern.target.corewyvernIL.support.GenContext;
+import wyvern.target.corewyvernIL.type.NominalType;
 import wyvern.target.corewyvernIL.type.ValueType;
 import wyvern.tools.errors.FileLocation;
 import wyvern.tools.typedAST.abs.AbstractExpressionAST;
 import wyvern.tools.typedAST.interfaces.CoreAST;
+import wyvern.tools.typedAST.interfaces.ExpressionAST;
 import wyvern.tools.typedAST.interfaces.TypedAST;
+import wyvern.tools.types.Type;
 
 /**
  * Represents a match statement in Wyvern.
@@ -19,7 +24,7 @@ import wyvern.tools.typedAST.interfaces.TypedAST;
  */
 public class Match extends AbstractExpressionAST implements CoreAST {
 
-    private TypedAST matchingOver;
+    private ExpressionAST matchingOver;
 
     private List<Case> cases;
     private Case defaultCase;
@@ -37,7 +42,7 @@ public class Match extends AbstractExpressionAST implements CoreAST {
         //clone original list so we have a canonical copy
         this.originalCaseList = new ArrayList<Case>(cases);
 
-        this.matchingOver = matchingOver;
+        this.matchingOver = (ExpressionAST) matchingOver;
         this.cases = cases;
 
         //find the default case and remove it from the typed cases
@@ -49,7 +54,6 @@ public class Match extends AbstractExpressionAST implements CoreAST {
         }
 
         cases.remove(defaultCase);
-
         this.location = location;
     }
 
@@ -62,7 +66,7 @@ public class Match extends AbstractExpressionAST implements CoreAST {
      * @param location
      */
     private Match(TypedAST matchingOver, List<Case> cases, Case defaultCase, FileLocation location) {
-        this.matchingOver = matchingOver;
+        this.matchingOver = (ExpressionAST) matchingOver;
         this.cases = cases;
         this.defaultCase = defaultCase;
         this.location = location;
@@ -75,7 +79,44 @@ public class Match extends AbstractExpressionAST implements CoreAST {
 
     @Override
     public Expression generateIL(GenContext ctx, ValueType expectedType, List<TypedModuleSpec> dependencies) {
-        // TODO Auto-generated method stub
-        return null;
+        // First, translate & typecheck the expression we're matching over
+        IExpr matchExpr = matchingOver.generateIL(ctx, null, dependencies);
+        ValueType expectedMatchType = matchExpr.typeCheck(ctx, null);
+
+        /** Our version of "type unification", where we use the first non-null type to be the type or super-type of all
+         * matched expressions/binders. Note that this is not really bidirectional since the matched expression
+         * type is the one we originally use.
+         */
+        for (Case c : cases) {
+            Type t = c.getTaggedTypeMatch();
+            ValueType vt = t == null ? null : t.getILType(ctx);
+            if (expectedMatchType == null) {
+                expectedMatchType = vt;
+            } else if (vt != null && !(vt.isSubtypeOf(expectedMatchType, ctx, null))) {
+                throw new RuntimeException("Case types don't agree");
+            }
+        }
+        ValueType matchType = expectedMatchType;
+
+
+        // Translate & typecheck each individual case, separately for the default case
+        Expression elseExpr = null;
+        if (defaultCase != null) {
+            ExpressionAST defaultExp = defaultCase.getAST();
+            elseExpr = (Expression) defaultExp.generateIL(ctx, expectedType, dependencies);
+        }
+        List<wyvern.target.corewyvernIL.Case> casesIL = cases.stream()
+                                                             .map(c -> c.generateILCase(ctx, matchType, (NominalType) expectedType, dependencies))
+                                                             .collect(Collectors.toList());
+        ValueType expectedCaseType = expectedType;
+        for (wyvern.target.corewyvernIL.Case c : casesIL) {
+            ValueType caseType = c.getBody().getType();
+            if (expectedCaseType != null && caseType != null && caseType != expectedType) {
+                throw new RuntimeException("Nope");
+            } else {
+                expectedCaseType = caseType;
+            }
+        }
+        return new wyvern.target.corewyvernIL.expression.Match((Expression) matchExpr, elseExpr, casesIL);
     }
 }

--- a/tools/src/wyvern/tools/typedAST/core/expressions/New.java
+++ b/tools/src/wyvern/tools/typedAST/core/expressions/New.java
@@ -5,9 +5,12 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import wyvern.target.corewyvernIL.decltype.DeclType;
 import wyvern.target.corewyvernIL.expression.Expression;
 import wyvern.target.corewyvernIL.modules.TypedModuleSpec;
 import wyvern.target.corewyvernIL.support.GenContext;
+import wyvern.target.corewyvernIL.type.RefinementType;
+import wyvern.target.corewyvernIL.type.StructuralType;
 import wyvern.target.corewyvernIL.type.ValueType;
 import wyvern.tools.errors.FileLocation;
 import wyvern.tools.typedAST.abs.AbstractExpressionAST;
@@ -95,7 +98,19 @@ public class New extends AbstractExpressionAST implements CoreAST {
             List<TypedModuleSpec> dependencies
             ) {
 
-        ValueType type = seq.inferStructuralType(ctx, this.self());
+        StructuralType structuralType = seq.inferStructuralType(ctx, this.self());
+        /* We need access to both the structural contents of the object and
+         * the expected type. The object can have extra decls on top of the
+         * expected type it has been ascribed to, and typechecking requires
+         * use of both.
+         */
+        ValueType type = null;
+        if (expectedType != null) {
+            List<DeclType> declTypes = structuralType.getDeclTypes();
+            type = new RefinementType(expectedType, declTypes, this);
+        } else {
+            type = structuralType;
+        }
 
         // Translate the declarations.
         GenContext thisContext = ctx.extend(
@@ -146,7 +161,7 @@ public class New extends AbstractExpressionAST implements CoreAST {
                 decls.add(setter);
             }
         }
-        // if type is not specified, infer
+
         return new wyvern.target.corewyvernIL.expression.New(
                 decls,
                 this.self(),

--- a/tools/src/wyvern/tools/typedAST/core/expressions/TaggedInfo.java
+++ b/tools/src/wyvern/tools/typedAST/core/expressions/TaggedInfo.java
@@ -3,7 +3,6 @@ package wyvern.tools.typedAST.core.expressions;
 import java.util.ArrayList;
 import java.util.List;
 
-import wyvern.tools.typedAST.core.declarations.AbstractTypeDeclaration;
 import wyvern.tools.types.Type;
 
 /**
@@ -14,30 +13,10 @@ import wyvern.tools.types.Type;
  */
 public class TaggedInfo {
 
-    // private static Map<TypeBinding, TaggedInfo> globalTagStore = new HashMap<TypeBinding, TaggedInfo>();
-    private static List<TaggedInfo> globalTagStoreList = new ArrayList<TaggedInfo>();
-
     private String tagName;
     private Type tagType;
-
-
-    // Note that caseOf and comprises only use Type when parsing, they should all be replaced with appropriate
-    // TaggedInfo during runtime or for type checking of tags to work.
     private Type caseOf;
-
     private List<Type> comprises;
-
-    public TaggedInfo getCaseOfTaggedInfo() {
-        return caseOfTaggedInfo;
-    }
-
-    public void setCaseOfTaggedInfo(TaggedInfo caseOfTaggedInfo) {
-        this.caseOfTaggedInfo = caseOfTaggedInfo;
-    }
-
-    // The only thing that matters is TaggedInfo address and caseOf/comprises relation below.
-    private TaggedInfo caseOfTaggedInfo;
-    // private List<TaggedInfo> comprisesTaggedInfos;
 
     /**
      * Constructs an empty TaggedInfo.
@@ -49,27 +28,21 @@ public class TaggedInfo {
 
     public TaggedInfo(String name, Type type) {
         this.comprises = new ArrayList<Type>();
-
         this.tagName = name;
         this.tagType = type;
     }
 
     /**
      * Constructs a TaggedInfo with the given caseOf, and no comprises.
-     * @param caseOf
+     * @param caseOf the datatype that this tagged type is a subtype of
      */
     public TaggedInfo(Type caseOf) {
         this(caseOf, null);
     }
 
-    public TaggedInfo(TaggedInfo caseOfTaggedInfo, List<TaggedInfo> comprisesTaggedInfos) {
-        this.caseOfTaggedInfo = caseOfTaggedInfo;
-        // this.comprisesTaggedInfos = comprisesTaggedInfos;
-    }
-
     /**
      * Constructs a TaggedInfo with the given comprises tags.
-     * @param comprises
+     * @param comprises the list of subtypes for a tagged type
      */
     public TaggedInfo(List<Type> comprises) {
         this(null, comprises);
@@ -80,8 +53,8 @@ public class TaggedInfo {
      *
      * comprises cannot be null or a NullPointerException is thrown.
      *
-     * @param caseOf
-     * @param comprises
+     * @param caseOf the datatype that this tagged type is a subtype of
+     * @param comprises the list of subtypes for a tagged type
      */
     public TaggedInfo(Type caseOf, List<Type> comprises) {
         this.caseOf = caseOf;
@@ -99,14 +72,9 @@ public class TaggedInfo {
      *
      * @param tagName
      */
-    public void setTagName(String tagName, AbstractTypeDeclaration td) {
+    public void setTagName(String tagName) {
         this.tagName = tagName;
-
-        // One of these will be null:
-        // this.td = td;
     }
-
-    // private AbstractTypeDeclaration td;
 
     /**
      * Gets the tag's name.
@@ -158,44 +126,6 @@ public class TaggedInfo {
     }
 
     public static void clearGlobalTaggedInfos() {
-//        globalTagStore = new HashMap<TypeBinding, TaggedInfo>();
-        globalTagStoreList = new ArrayList<TaggedInfo>();
+        // TODO Auto-generated method stub
     }
-
-//    public static Map<TypeBinding, TaggedInfo> getGlobalTagStore() {
-//        return globalTagStore;
-//    }
-
-    /**
-     * Returns the global tag store, as a list.
-     *
-     * This has the same contents as the Map<String, TaggedInfo> map, just
-     * without them being mapped by the tag name.
-     *
-     * @return
-     */
-    public static List<TaggedInfo> getGlobalTagStoreList() {
-        return globalTagStoreList;
-    }
-
-//    public static TaggedInfo lookupTag(TypeBinding t) {
-//        TaggedInfo info = globalTagStore.get(t);
-//
-//        return info;
-//    }
-
-    public static TaggedInfo lookupTagByType(Type t) {
-        if (t == null) {
-            return null;
-        }
-
-        for (TaggedInfo i : globalTagStoreList) {
-
-            if (i.tagType.equals(t)) {
-                return i;
-            }
-        }
-        return null;
-    }
-
 }


### PR DESCRIPTION
Summary:
This commit fully implements the simple datatypes from the `typedAST` all the way to interpretation. Right now, no new constructs were added to the `typedAST`; the main difference is that tagging information is carried through in the `TypeDeclaration` which is then translated into the IL as a `DataType`. Existing classes are used to implement pattern matching, but now fully implemented with translation and interpretation. Parametrized datatypes are not currently fully working.

Testing:
This commit contains a few new test cases.
- `taggedList.wyv` passes
- `parametrizedList.wyv` is a wip: the type declarations compile but the pattern matching does not