### PR TITLE
Add test for circular imports

### DIFF
--- a/tools/src/wyvern/tools/tests/ModuleSystemTests.java
+++ b/tools/src/wyvern/tools/tests/ModuleSystemTests.java
@@ -1,5 +1,8 @@
 package wyvern.tools.tests;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -7,8 +10,10 @@ import org.junit.experimental.categories.Category;
 import wyvern.target.corewyvernIL.expression.IntegerLiteral;
 import wyvern.target.corewyvernIL.support.Util;
 import wyvern.tools.errors.ErrorMessage;
+import wyvern.tools.errors.ToolError;
 import wyvern.tools.imports.extensions.WyvernResolver;
 import wyvern.tools.parsing.coreparser.ParseException;
+import wyvern.tools.tests.suites.CurrentlyBroken;
 import wyvern.tools.tests.suites.RegressionTests;
 
 @Category(RegressionTests.class)
@@ -93,4 +98,18 @@ public class ModuleSystemTests {
     public void testSimpleADTWithRenamingRequire() throws ParseException {
         TestUtil.doTestScriptModularly("modules.simpleADTdriver3", Util.intType(), new IntegerLiteral(5));
     }
+    
+    @Test
+    @Category(CurrentlyBroken.class)
+    public void testCircularImports() throws ParseException {
+        String errorMessage = "testCircularImports should catch a ToolError of type ErrorMesasge.IMPORT_CYCLE";
+        try {
+            TestUtil.doTestScriptModularly("modules.circular1", Util.unitType(), Util.unitValue());
+            fail(errorMessage);
+        } catch (ToolError te) {
+            assertEquals(errorMessage, ErrorMessage.IMPORT_CYCLE, te.getTypecheckingErrorMessage());
+        }
+    }
+
+    
 }

--- a/tools/src/wyvern/tools/tests/modules/circular1.wyv
+++ b/tools/src/wyvern/tools/tests/modules/circular1.wyv
@@ -1,0 +1,3 @@
+// Imports circular2, which imports circular1, which imports circular2, ... 
+import modules.circular2
+1

--- a/tools/src/wyvern/tools/tests/modules/circular2.wyv
+++ b/tools/src/wyvern/tools/tests/modules/circular2.wyv
@@ -1,0 +1,3 @@
+// Imports circular1, which imports circular2, which imports circular1, ... 
+import modules.circular1
+2


### PR DESCRIPTION
This adds a test for #159 

I've also got a quick solution which solves the problem and passes the regression tests. It involves changing `wyvern.target.corewyvernIL.support` so it looks like this:

```Java
public class ModuleResolver {

    /* omitted */

    private Set<String> modulesBeingResolved = new HashSet<>();

    /* omitted */

    public Module resolveModule(String qualifiedName, boolean toplevel) {
        if (modulesBeingResolved.contains(qualifiedName)) {
            ToolError.reportError(ErrorMessage.IMPORT_CYCLE, HasLocation.UNKNOWN,
                    "Cycle found when resolving " + qualifiedName);
        }
        if (!moduleCache.containsKey(qualifiedName)) {
            File f = resolve(qualifiedName, false);
            modulesBeingResolved.add(qualifiedName);
            moduleCache.put(qualifiedName, load(qualifiedName, f, toplevel));
            modulesBeingResolved.remove(qualifiedName);
        }
        return moduleCache.get(qualifiedName);
    }

    /* omitted */

}
```

A nicer solution might be to modify `resolveModule` so that before doing any resolution, it first performs a depth-first search to find any cycles in the dependency graph. This would also let you report the exact cycle to the programmer.

What do you think?
