### PR TITLE
Report error when a module has a cyclic dependency

### DIFF
--- a/tools/src/wyvern/tools/tests/ModuleSystemTests.java
+++ b/tools/src/wyvern/tools/tests/ModuleSystemTests.java
@@ -13,7 +13,6 @@ import wyvern.tools.errors.ErrorMessage;
 import wyvern.tools.errors.ToolError;
 import wyvern.tools.imports.extensions.WyvernResolver;
 import wyvern.tools.parsing.coreparser.ParseException;
-import wyvern.tools.tests.suites.CurrentlyBroken;
 import wyvern.tools.tests.suites.RegressionTests;
 
 @Category(RegressionTests.class)
@@ -22,7 +21,8 @@ public class ModuleSystemTests {
     private static final String BASE_PATH = TestUtil.BASE_PATH;
     private static final String PATH = BASE_PATH + "modules/";
 
-    @BeforeClass public static void setupResolver() {
+    @BeforeClass
+    public static void setupResolver() {
         TestUtil.setPaths();
         WyvernResolver.getInstance().addPath(PATH);
     }
@@ -35,42 +35,32 @@ public class ModuleSystemTests {
 
     @Test
     public void testADT() throws ParseException {
-        TestUtil.doTestScriptModularly("modules.listClient",
-                Util.intType(),
-                new IntegerLiteral(5));
+        TestUtil.doTestScriptModularly("modules.listClient", Util.intType(), new IntegerLiteral(5));
     }
 
     @Test
     public void testTransitiveAuthorityGood() throws ParseException {
-        TestUtil.doTestScriptModularly("modules.databaseClientGood",
-                Util.intType(),
-                new IntegerLiteral(1));
+        TestUtil.doTestScriptModularly("modules.databaseClientGood", Util.intType(), new IntegerLiteral(1));
     }
 
     @Test
     public void testTransitiveAuthorityBad() throws ParseException {
-        TestUtil.doTestScriptModularlyFailing("modules.databaseClientBad",
-                ErrorMessage.NO_SUCH_METHOD);
+        TestUtil.doTestScriptModularlyFailing("modules.databaseClientBad", ErrorMessage.NO_SUCH_METHOD);
     }
 
     @Test
     public void testTopLevelVars() throws ParseException {
-        TestUtil.doTestScriptModularly("modules.databaseUser",
-                Util.intType(),
-                new IntegerLiteral(10));
+        TestUtil.doTestScriptModularly("modules.databaseUser", Util.intType(), new IntegerLiteral(10));
     }
 
     @Test
     public void testTopLevelVarsWithAliasing() throws ParseException {
-        TestUtil.doTestScriptModularly("modules.databaseUserTricky",
-                Util.intType(),
-                new IntegerLiteral(10));
+        TestUtil.doTestScriptModularly("modules.databaseUserTricky", Util.intType(), new IntegerLiteral(10));
     }
 
     @Test
     public void testTopLevelVarGet() throws ParseException {
-        String source = "var v : Int = 5\n"
-                + "v\n";
+        String source = "var v : Int = 5\n" + "v\n";
 
         TestUtil.doTestInt(source, 5);
     }
@@ -78,9 +68,7 @@ public class ModuleSystemTests {
     @Test
     public void testTopLevelVarSet() throws ParseException {
 
-        String source = "var v : Int = 5\n"
-                + "v = 10\n"
-                + "v\n";
+        String source = "var v : Int = 5\n" + "v = 10\n" + "v\n";
         TestUtil.doTestInt(source, 10);
     }
 
@@ -98,18 +86,38 @@ public class ModuleSystemTests {
     public void testSimpleADTWithRenamingRequire() throws ParseException {
         TestUtil.doTestScriptModularly("modules.simpleADTdriver3", Util.intType(), new IntegerLiteral(5));
     }
-    
+
     @Test
-    @Category(CurrentlyBroken.class)
-    public void testCircularImports() throws ParseException {
-        String errorMessage = "testCircularImports should catch a ToolError of type ErrorMesasge.IMPORT_CYCLE";
+    public void testCyclicImports() throws ParseException {
+        String errorMessage = "testCyclicImports should catch a ToolError of type ErrorMesasge.IMPORT_CYCLE";
         try {
-            TestUtil.doTestScriptModularly("modules.circular1", Util.unitType(), Util.unitValue());
+            TestUtil.doTestScriptModularly("modules.cyclic.cyclic1a", Util.unitType(), Util.unitValue());
             fail(errorMessage);
         } catch (ToolError te) {
             assertEquals(errorMessage, ErrorMessage.IMPORT_CYCLE, te.getTypecheckingErrorMessage());
         }
     }
 
-    
+    @Test
+    public void testLongCyclicImport() throws ParseException {
+        String errorMessage = "testLongCyclicImports should catch a ToolError of type ErrorMesasge.IMPORT_CYCLE";
+        try {
+            TestUtil.doTestScriptModularly("modules.cyclic.cyclic2a", Util.unitType(), Util.unitValue());
+            fail(errorMessage);
+        } catch (ToolError te) {
+            assertEquals(errorMessage, ErrorMessage.IMPORT_CYCLE, te.getTypecheckingErrorMessage());
+        }
+    }
+
+    @Test
+    public void testCircularImportNotInvolvingTopLevel() throws ParseException {
+        String errorMessage = "testCyclicImports should catch a ToolError of type ErrorMesasge.IMPORT_CYCLE";
+        try {
+            TestUtil.doTestScriptModularly("modules.cyclic.cyclic3a", Util.unitType(), Util.unitValue());
+            fail(errorMessage);
+        } catch (ToolError te) {
+            assertEquals(errorMessage, ErrorMessage.IMPORT_CYCLE, te.getTypecheckingErrorMessage());
+        }
+    }
+
 }

--- a/tools/src/wyvern/tools/tests/modules/circular1.wyv
+++ b/tools/src/wyvern/tools/tests/modules/circular1.wyv
@@ -1,3 +1,0 @@
-// Imports circular2, which imports circular1, which imports circular2, ... 
-import modules.circular2
-1

--- a/tools/src/wyvern/tools/tests/modules/circular2.wyv
+++ b/tools/src/wyvern/tools/tests/modules/circular2.wyv
@@ -1,3 +1,0 @@
-// Imports circular1, which imports circular2, which imports circular1, ... 
-import modules.circular1
-2

--- a/tools/src/wyvern/tools/tests/modules/cyclic/cyclic1a.wyv
+++ b/tools/src/wyvern/tools/tests/modules/cyclic/cyclic1a.wyv
@@ -1,0 +1,3 @@
+// Imports cyclic1b, which imports cyclic1a, which imports cyclic1b, ... 
+import modules.cyclic.cyclic1b
+1

--- a/tools/src/wyvern/tools/tests/modules/cyclic/cyclic1b.wyv
+++ b/tools/src/wyvern/tools/tests/modules/cyclic/cyclic1b.wyv
@@ -1,0 +1,3 @@
+// Imports cyclic1a, which imports cyclic1b, which imports cyclic1a, ... 
+import modules.cyclic.cyclic1a
+2

--- a/tools/src/wyvern/tools/tests/modules/cyclic/cyclic2a.wyv
+++ b/tools/src/wyvern/tools/tests/modules/cyclic/cyclic2a.wyv
@@ -1,0 +1,3 @@
+// imports cyclic2b, which imports cyclic2c, which imports cyclic2a...
+import modules.cyclic.cyclic2b
+1

--- a/tools/src/wyvern/tools/tests/modules/cyclic/cyclic2b.wyv
+++ b/tools/src/wyvern/tools/tests/modules/cyclic/cyclic2b.wyv
@@ -1,0 +1,3 @@
+// imports cyclic2c, which imports cyclic2a, which imports cyclic2b...
+import modules.cyclic.cyclic2b
+2

--- a/tools/src/wyvern/tools/tests/modules/cyclic/cyclic2c.wyv
+++ b/tools/src/wyvern/tools/tests/modules/cyclic/cyclic2c.wyv
@@ -1,0 +1,3 @@
+// imports cyclic2a, which imports cyclic2b, which imports cyclic2c...
+import modules.cyclic.cyclic2c
+3

--- a/tools/src/wyvern/tools/tests/modules/cyclic/cyclic3a.wyv
+++ b/tools/src/wyvern/tools/tests/modules/cyclic/cyclic3a.wyv
@@ -1,0 +1,3 @@
+// imports cyclic1a, which imports cyclic1b, which imports cyclic1a...
+import modules.cyclic.cyclic1a
+1


### PR DESCRIPTION
This adds a solution for #159. `ModuleResolver` now keeps track of the modules it is trying to resolve at any given point in a field called `modulesBeingResolved`. Before resolving a module, it first checks if that module is already in `modulesBeingResolved`.

I think this turns module resolution into O(M^2), where M = the number of modules, since for every module (O(M) of them) you must check whether it is in `modulesBeingResolved` (also O(M)).

Also adds two more tests which check the following cases:
* a -> b -> c -> a
* a -> b -> c -> b
