### PR TITLE
Add bootstrapping and backend tests to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,26 @@
+# need to use sudo-enabled containers for additional RAM
+sudo: required
 language: java
 jdk: oraclejdk8
 python:
   - "3.6"
+cache:
+  directories:
+    - "backend/node_modules"
+install:
+  - cd backend
+  - npm install
+  - cd ..
+before_script:
+  - export WYVERN_HOME="$(pwd)"
+  - export _JAVA_OPTIONS="-Xmx6144m -Xms512m"
 script:
   - cd tools
   - ant test
+  - cd ../backend
+  - ./bootstrap.sh travis
+  - ./test.sh
 notifications:
   email:
     recipients:
       - jonathan.aldrich@cs.cmu.edu
-group: deprecated-2017Q1        # try to work around TravisCI update that breaks ant junit task

--- a/backend/bootstrap.sh
+++ b/backend/bootstrap.sh
@@ -4,6 +4,17 @@ set -e
 WYBY=$WYVERN_HOME/bin/wyby
 WYVERN=$WYVERN_HOME/bin/wyvern
 
+if [ "$1" = "travis" ]; then
+    # keep travis alive
+    function bell() {
+        while true; do
+            sleep 60
+            echo -n "."
+        done
+    }
+    bell &
+fi
+
 (
 cd src/
 rm -f main_js.wyb
@@ -14,3 +25,7 @@ time $WYVERN main_java.wyv > ../boot.js
 
 ./self-bootstrap.sh
 diff -q boot.js boot.js.old || (echo "sanity check failed" && exit 1)
+
+if [ "$1" = "travis" ]; then
+    kill %1
+fi

--- a/tools/src/wyvern/tools/BytecodeCompiler.java
+++ b/tools/src/wyvern/tools/BytecodeCompiler.java
@@ -76,6 +76,7 @@ public final class BytecodeCompiler {
 
         } catch (ToolError e) {
             System.err.println(e.getMessage());
+            System.exit(1);
         }
     }
 

--- a/tools/src/wyvern/tools/Interpreter.java
+++ b/tools/src/wyvern/tools/Interpreter.java
@@ -75,6 +75,7 @@ public final class Interpreter {
             System.err.println("Parse error: " + e.getMessage());*/
         } catch (ToolError e) {
             System.err.println(e.getMessage());
+            System.exit(1);
         }
     }
 


### PR DESCRIPTION
Also fixes compiler/interpreter exit codes.

Travis instances by default only have 4G of RAM. We need at least 6G to bootstrap in a reasonable amount of time. As suggested by the [travis docs](https://docs.travis-ci.com/user/reference/overview/#Virtualisation-Environment-vs-Operating-System), this patch adds `sudo: required` so we get the GCE-based CI servers with 8G of RAM. The damage here is that these instances take longer to boot (20-50s vs 1-6s).

I removed what looks to be an old workaround introduced in 252e5a6b1. Let me know if this should stay.

The patch also adds some code to the bootstrap script which prints '.' every minute so travis doesn't time out builds.

Overall, this increases CI run times from 2min -> 20min. Bootstrapping takes 16m30s on travis.