### PR TITLE
Allow tail calls through if

### DIFF
--- a/backend/examples/tco.wyv
+++ b/backend/examples/tco.wyv
@@ -1,17 +1,11 @@
 require stdout
 
-datatype Bool
-    True
-    False
-
-def Bool(b: Boolean): Bool
-    b.ifTrue(() => True(), () => False())
-
 def id(n: Int): Int
     def count(n: Int, acc: Int): Int
-        match Bool(n == 0):
-            _: True => acc
-            _: False => recur count(n - 1, acc + 1)
+        if (n == 0)
+                acc
+            else
+                recur count(n - 1, acc + 1)
     count(n, 0)
 
 stdout.printInt(id(10000))

--- a/backend/src/emit_js.wyv
+++ b/backend/src/emit_js.wyv
@@ -100,6 +100,14 @@ def ifTrue(cond: wyb_ast.Expression, trueArm: wyb_ast.Expression, falseArm: wyb_
     val f = visitExpression(falseArm)
     LiftedExpression(c.lifting + t.lifting + f.lifting, "(" + c.expr + "?" + t.expr + ".apply()" + ":" + f.expr + ".apply())")
 
+def visitInlineIf(ii: wyb_ast.InlineIf): LiftedExpression
+    val c = visitExpression(ii.cond)
+    val t = visitExpression(ii.trueExpr)
+    val f = visitExpression(ii.falseExpr)
+    val temp = tempVar()
+    val lifting = c.lifting + "let " + temp + ";if (" + c.expr + ") {" + t.lifting + temp + " = " + t.expr + "; } else { " + f.lifting + temp + " = " + f.expr + "; }"
+    LiftedExpression(lifting, temp)
+
 def generateTailCall(methodName: String, argumentJS: List[LiftedExpression]): LiftedExpression
     var l: String = ""
     var i: Int = 0
@@ -276,6 +284,7 @@ def visitExpression(e: wyb_ast.Expression): LiftedExpression = match e:
     s: wyb_ast.StringLiteral => noLifting('"' + unescape(s.s) + '"')
     n: wyb_ast.NewExpression => noLifting(visitNewExpression(n))
     c: wyb_ast.CallExpression => visitCallExpression(c)
+    ii: wyb_ast.InlineIf => visitInlineIf(ii)
     s: wyb_ast.SequenceExpression => sequenceExpression(s)
     poe: wyb_ast.StaticCallExpression => visitStaticCallExpression(poe)
     me: wyb_ast.MatchExpression => visitMatchExpression(me)

--- a/backend/src/inline_if.wyv
+++ b/backend/src/inline_if.wyv
@@ -1,4 +1,4 @@
-module tco
+module inline_if
 
 import wyvern.option
 import wyvern.collections.list
@@ -9,46 +9,42 @@ import util
 type List = list.List
 type Option = option.Option
 
-def any(l: List[Boolean]): Boolean
-    l.find(e: Boolean => e).isDefined
 
 def visitStatement(s: wyb_ast.Statement): wyb_ast.Statement = match s:
     e: wyb_ast.E => wyb_ast.E(visitExpression(e.expression))
     d: wyb_ast.D => wyb_ast.D(visitDeclaration(d.declaration))
 
-// This is exponential
-def visitMethodDeclaration(md: wyb_ast.MethodDeclaration): wyb_ast.MethodDeclaration
-   wyb_ast.MethodDeclaration(md.methodName, md.arguments, md.returnType, visitExpression(md.body), containsTailCalls(md.body)) 
-
-def containsTailCalls(e: wyb_ast.Expression): Boolean = match e:
-    se: wyb_ast.SequenceExpression => any(se.statements.map[Boolean](s => statementContainsTailCalls(s)))
-    ce: wyb_ast.CallExpression => ce.isTailCall
-    me: wyb_ast.MatchExpression => matchContainsTallCalls(me)
-    default => false
-
-def statementContainsTailCalls(s: wyb_ast.Statement): Boolean = match s:
-    e: wyb_ast.E => containsTailCalls(e.expression)
-    default => false
-
-def matchContainsTallCalls(me: wyb_ast.MatchExpression): Boolean
-    any(me.arms.map[Boolean](a => armContainsTailCalls(a))) || me.elseClause.map[Boolean](x => containsTailCalls(x)).getOrElse(() => false)
-
-def armContainsTailCalls(a: wyb_ast.MatchArm): Boolean
-    containsTailCalls(a.e)
-
 def visitDeclaration(d: wyb_ast.Declaration): wyb_ast.Declaration = match d:
     vd: wyb_ast.VariableDeclaration => wyb_ast.VariableDeclaration(vd.declarationType, vd.variable, vd.t, visitExpression(vd.initializer))
-    md: wyb_ast.MethodDeclaration => visitMethodDeclaration(md)
-    td: wyb_ast.TypeDeclaration => td
+    md: wyb_ast.MethodDeclaration => wyb_ast.MethodDeclaration(md.methodName, md.arguments, md.returnType, visitExpression(md.body), md.tco)
+    td: wyb_ast.TypeDeclaration => wyb_ast.TypeDeclaration(td.name, td.typeDesc)
+
+def inlineIf(args: List[wyb_ast.Expression]): wyb_ast.Expression
+    val cond = util.unwrap[wyb_ast.Expression](args.get(0))
+    val ifBlock: Dyn = util.unwrap[wyb_ast.Expression](args.get(1))
+    val trueExpr = util.unwrap[wyb_ast.MethodDeclaration](ifBlock.declarations.get(0)).body
+    val falseExpr = util.unwrap[wyb_ast.MethodDeclaration](ifBlock.declarations.get(1)).body
+    wyb_ast.InlineIf(cond, trueExpr, falseExpr)
+
+def visitCallExpression(ce: wyb_ast.CallExpression): wyb_ast.Expression
+    val r = visitExpression(ce.receiver)
+    val isIf = match r:
+        v: wyb_ast.Var => v.v == "if"
+        default => false
+    if (isIf)
+            val args = visitExpressions(ce.arguments)
+            inlineIf(args)
+        else
+            wyb_ast.CallExpression(r, ce.method, visitExpressions(ce.arguments), ce.isTailCall)
 
 def visitExpression(e: wyb_ast.Expression): wyb_ast.Expression = match e:
-    v: wyb_ast.Var => v
+    v: wyb_ast.Var => wyb_ast.Var(v.v)
     i: wyb_ast.IntegerLiteral => i
     b: wyb_ast.BooleanLiteral => b
     f: wyb_ast.FloatLiteral => f
     s: wyb_ast.StringLiteral => s
     ne: wyb_ast.NewExpression => wyb_ast.NewExpression(ne.t, ne.thisVariable, ne.declarations.map[wyb_ast.Declaration](d => visitDeclaration(d)))
-    ce: wyb_ast.CallExpression => wyb_ast.CallExpression(visitExpression(ce.receiver), ce.method, visitExpressions(ce.arguments), ce.isTailCall)
+    ce: wyb_ast.CallExpression => visitCallExpression(ce)
     pce: wyb_ast.StaticCallExpression => wyb_ast.StaticCallExpression(visitExpression(pce.receiver), pce.receiverType, pce.method, visitExpressions(pce.arguments))
     se: wyb_ast.SequenceExpression => wyb_ast.SequenceExpression(se.statements.map[wyb_ast.Statement](s => visitStatement(s)))
     me: wyb_ast.MatchExpression => visitMatch(me)
@@ -69,4 +65,3 @@ def visitMatch(me: wyb_ast.MatchExpression): wyb_ast.MatchExpression
 
 def visitExpressions(expressions: List[wyb_ast.Expression]): List[wyb_ast.Expression]
     expressions.map[wyb_ast.Expression](e => visitExpression(e))
-

--- a/backend/src/main.wyv
+++ b/backend/src/main.wyv
@@ -7,14 +7,16 @@ import wyb_ast
 import rename
 import emit_js
 import util
-import tco
+import mark_tco
+import inline_if
 
 val support = support.apply(platform)
 
 val from_protobuf = from_protobuf.apply(support)
 
 def compileModule(modulePath: String, e: wyb_ast.Expression): String
-    val t = tco.visitExpression(e)
+    val i = inline_if.visitExpression(e)
+    val t = mark_tco.visitExpression(i)
     val r = rename.visitExpression(t)
     val e = emit_js.visitExpression(r)
     e.lifting + "let " + rename.renameVariable(modulePath) + " = " + e.expr + ";"

--- a/backend/src/mark_tco.wyv
+++ b/backend/src/mark_tco.wyv
@@ -1,0 +1,74 @@
+module tco
+
+import wyvern.option
+import wyvern.collections.list
+
+import wyb_ast
+import util
+
+type List = list.List
+type Option = option.Option
+
+def any(l: List[Boolean]): Boolean
+    l.find(e: Boolean => e).isDefined
+
+def visitStatement(s: wyb_ast.Statement): wyb_ast.Statement = match s:
+    e: wyb_ast.E => wyb_ast.E(visitExpression(e.expression))
+    d: wyb_ast.D => wyb_ast.D(visitDeclaration(d.declaration))
+
+// This is exponential
+def visitMethodDeclaration(md: wyb_ast.MethodDeclaration): wyb_ast.MethodDeclaration
+   wyb_ast.MethodDeclaration(md.methodName, md.arguments, md.returnType, visitExpression(md.body), containsTailCalls(md.body)) 
+
+def containsTailCalls(e: wyb_ast.Expression): Boolean = match e:
+    se: wyb_ast.SequenceExpression => any(se.statements.map[Boolean](s => statementContainsTailCalls(s)))
+    ce: wyb_ast.CallExpression => ce.isTailCall
+    ii: wyb_ast.InlineIf => containsTailCalls(ii.cond) || containsTailCalls(ii.trueExpr) || containsTailCalls(ii.falseExpr)
+    me: wyb_ast.MatchExpression => matchContainsTallCalls(me)
+    default => false
+
+def statementContainsTailCalls(s: wyb_ast.Statement): Boolean = match s:
+    e: wyb_ast.E => containsTailCalls(e.expression)
+    default => false
+
+def matchContainsTallCalls(me: wyb_ast.MatchExpression): Boolean
+    any(me.arms.map[Boolean](a => armContainsTailCalls(a))) || me.elseClause.map[Boolean](x => containsTailCalls(x)).getOrElse(() => false)
+
+def armContainsTailCalls(a: wyb_ast.MatchArm): Boolean
+    containsTailCalls(a.e)
+
+def visitDeclaration(d: wyb_ast.Declaration): wyb_ast.Declaration = match d:
+    vd: wyb_ast.VariableDeclaration => wyb_ast.VariableDeclaration(vd.declarationType, vd.variable, vd.t, visitExpression(vd.initializer))
+    md: wyb_ast.MethodDeclaration => visitMethodDeclaration(md)
+    td: wyb_ast.TypeDeclaration => td
+
+def visitExpression(e: wyb_ast.Expression): wyb_ast.Expression = match e:
+    v: wyb_ast.Var => v
+    i: wyb_ast.IntegerLiteral => i
+    b: wyb_ast.BooleanLiteral => b
+    f: wyb_ast.FloatLiteral => f
+    s: wyb_ast.StringLiteral => s
+    ne: wyb_ast.NewExpression => wyb_ast.NewExpression(ne.t, ne.thisVariable, ne.declarations.map[wyb_ast.Declaration](d => visitDeclaration(d)))
+    ce: wyb_ast.CallExpression => wyb_ast.CallExpression(visitExpression(ce.receiver), ce.method, visitExpressions(ce.arguments), ce.isTailCall)
+    ii: wyb_ast.InlineIf => wyb_ast.InlineIf(visitExpression(ii.cond), visitExpression(ii.trueExpr), visitExpression(ii.falseExpr))
+    pce: wyb_ast.StaticCallExpression => wyb_ast.StaticCallExpression(visitExpression(pce.receiver), pce.receiverType, pce.method, visitExpressions(pce.arguments))
+    se: wyb_ast.SequenceExpression => wyb_ast.SequenceExpression(se.statements.map[wyb_ast.Statement](s => visitStatement(s)))
+    me: wyb_ast.MatchExpression => visitMatch(me)
+    ae: wyb_ast.AccessExpression => wyb_ast.AccessExpression(visitExpression(ae.e), ae.field)
+    ae: wyb_ast.AssignmentExpression => wyb_ast.AssignmentExpression(visitExpression(ae.e), ae.field, visitExpression(ae.v))
+
+def visitMatchArm(a: wyb_ast.MatchArm): wyb_ast.MatchArm
+    val v = a.variable
+    val p = a.path
+    val e = visitExpression(a.e)
+    wyb_ast.MatchArm(v, p, e)
+
+def visitMatch(me: wyb_ast.MatchExpression): wyb_ast.MatchExpression
+    val e = visitExpression(me.e)
+    val arms = me.arms.map[wyb_ast.MatchArm](a => visitMatchArm(a))
+    val elseClause = me.elseClause.map[wyb_ast.Expression](x => visitExpression(x))
+    wyb_ast.MatchExpression(e, arms, elseClause)
+
+def visitExpressions(expressions: List[wyb_ast.Expression]): List[wyb_ast.Expression]
+    expressions.map[wyb_ast.Expression](e => visitExpression(e))
+

--- a/backend/src/print_bytecode.wyv
+++ b/backend/src/print_bytecode.wyv
@@ -8,6 +8,6 @@ val support = support.apply(java)
 
 // Designed to work with interpreter only right now
 
-val test = support.loadBytecode("../test.wyb")
+val test = support.loadBytecode("../examples/tco.wyb")
 val expression = test.getModules(0).getValueModule().getExpression()
 stdout.print(test.toString())

--- a/backend/src/rename.wyv
+++ b/backend/src/rename.wyv
@@ -80,6 +80,7 @@ def visitExpression(e: wyb_ast.Expression): wyb_ast.Expression = match e:
     s: wyb_ast.StringLiteral => s
     ne: wyb_ast.NewExpression => wyb_ast.NewExpression(visitType(ne.t), renameVariable(ne.thisVariable), ne.declarations.map[wyb_ast.Declaration](d => visitDeclaration(d)))
     ce: wyb_ast.CallExpression => wyb_ast.CallExpression(visitExpression(ce.receiver), renameVariable(ce.method), visitExpressions(ce.arguments), ce.isTailCall)
+    ii: wyb_ast.InlineIf => wyb_ast.InlineIf(visitExpression(ii.cond), visitExpression(ii.trueExpr), visitExpression(ii.falseExpr))
     pce: wyb_ast.StaticCallExpression => wyb_ast.StaticCallExpression(visitExpression(pce.receiver), pce.receiverType, pce.method, visitExpressions(pce.arguments))
     se: wyb_ast.SequenceExpression => wyb_ast.SequenceExpression(se.statements.map[wyb_ast.Statement](s => visitStatement(s)))
     me: wyb_ast.MatchExpression => visitMatch(me)

--- a/backend/src/wyb_ast.wyv
+++ b/backend/src/wyb_ast.wyv
@@ -75,6 +75,7 @@ resource datatype Expression
     NewExpression(t: Type, thisVariable: String, declarations: List[Declaration])
     CallExpression(receiver: Expression, method: String, arguments: List[Expression], isTailCall: Boolean)
     StaticCallExpression(receiver: Expression, receiverType: String, method: String, arguments: List[Expression])
+    InlineIf(cond: Expression, trueExpr: Expression, falseExpr: Expression)
     SequenceExpression(statements: List[Statement])
     MatchExpression(e: Expression, arms: List[MatchArm], elseClause: Option[Expression])
     AccessExpression(e: Expression, field: String)


### PR DESCRIPTION
Achieved via a hack which inlines if statements by looking for the
specific CoreWyvernIL pattern emitted by the frontend. Temporary measure
until ifTSL is rewritten as a macro so intermediate methods are not
generated for if arms.