### PR TITLE
Separately cache lifted and unlifted modules

### DIFF
--- a/tools/src/wyvern/target/corewyvernIL/modules/Module.java
+++ b/tools/src/wyvern/target/corewyvernIL/modules/Module.java
@@ -19,6 +19,7 @@ public class Module {
         this.spec = spec;
         this.expr = program;
         this.dependencies = dependencies;
+        spec.setModule(this);
     }
 
     public TypedModuleSpec getSpec() {

--- a/tools/src/wyvern/target/corewyvernIL/modules/TypedModuleSpec.java
+++ b/tools/src/wyvern/target/corewyvernIL/modules/TypedModuleSpec.java
@@ -6,6 +6,7 @@ public class TypedModuleSpec extends ModuleSpec {
     private final ValueType type;
     private final String definedTypeName;
     private final String definedValueName;
+    private Module module = null;
 
     public TypedModuleSpec(String qualifiedName, ValueType type, String typeName, String valueName) {
         super(qualifiedName);
@@ -34,4 +35,14 @@ public class TypedModuleSpec extends ModuleSpec {
         return definedValueName;
     }
 
+    public Module getModule() {
+        return this.module;
+    }
+
+    public void setModule(Module module) {
+        if (this.module != null) {
+            throw new IllegalStateException("Assign multiple modules to a TypedModuleSpec");
+        }
+        this.module = module;
+    }
 }


### PR DESCRIPTION
This pull request fixes the bug that is introduced by adding quantification lifting.

The original cache caches modules by the name of the module. So if a module is both lifted and not lifted, there will be only one copy, instead of two, in the cache. To solve this problem, I created two caches to separately cache lifted and unlifted modules. I also added a private field to TypedModuleSpec of type Module, to avoid resolving module by its qualifiedName. 