### PR TITLE
Fixes a bug in the new Java IO library

### DIFF
--- a/stdlib/platform/java/fileSystem.wyv
+++ b/stdlib/platform/java/fileSystem.wyv
@@ -24,7 +24,8 @@ def makeFile(path: String) : File = new
                 val line = file.readLineFromFile(br)
                 if (file.isNull(line))
                     option.None[String]()
-                option.Some[String](line)
+                  else
+                    option.Some[String](line)
             def readFully() : String
                 file.readFullyFile(br)
             def close() : Unit


### PR DESCRIPTION
When reading a file in line-by-line, at the end of the file, Java's null was put into Wyvern's Option.