### PR TITLE
Better organizes String operations

### DIFF
--- a/backend/examples/algebra.wyv
+++ b/backend/examples/algebra.wyv
@@ -170,7 +170,7 @@ def toString(t : Term) : String
 
 def d(wrt : String, t : Term) : Term = match t:
   t:Constant => Constant(0.0)
-  t:Variable => if (String.equals(t.name, wrt))
+  t:Variable => if (wrt.equals(t.name))
                   Constant(1.0)
                  else
                   Constant(0.0)
@@ -466,7 +466,7 @@ def printInfo(t : Term, xVal : Number, yVal : Number) : Unit
   val xString : String = numberToString(xVal)
   val yString : String = numberToString(yVal)
 
-  var bindings : Map = map.make((x : String, y : String) => String.equals(x, y))
+  var bindings : Map = map.make((x : String, y : String) => x.equals(y))
   bindings.put("x", xVal)
   bindings.put("y", yVal)
 

--- a/backend/src/emit_js.wyv
+++ b/backend/src/emit_js.wyv
@@ -223,7 +223,7 @@ def visitStaticCallExpression(e: wyb_ast.StaticCallExpression): LiftedExpression
         elif (op == "length")
             assert e.arguments.length() == 0
             LiftedExpression(receiverJS.lifting, "(" + receiverJS.expr + ").length")
-        elif (op == "charAt" || op == "substring" || op == "concat")
+        elif (op == "charAt" || op == "substring" || op == "concat" || op == "equals")
             visitExpression(wyb_ast.CallExpression(e.receiver, op, e.arguments, false))
         elif (op == "floor")
             LiftedExpression(receiverJS.lifting, "Math.floor(" + receiverJS.expr + ")")

--- a/backend/src/main.wyv
+++ b/backend/src/main.wyv
@@ -42,6 +42,7 @@ def compile(wyb: Dyn): Unit
     stdout.print("String.prototype._EQUAL__EQUAL_ = function(x) { return this == x; };")
     stdout.print("String.prototype._PLUS_ = function(x) { return this + x; };")
     stdout.print("String.prototype._length = function(x) { return this.length; };")
+    stdout.print("String.prototype.equals = function(x) { return this === x; };")
     def importLoop(i: Int, c: Int): Unit
         if (i < c)
             val imp = wyb.getImports(i)

--- a/backend/stdlib/support/string.js
+++ b/backend/stdlib/support/string.js
@@ -1,9 +1,5 @@
 const sprintfjs = require("sprintf-js");
 
-exports.testEqual = function(s1, s2) {
-    return s1 === s2;
-}
-
 exports.ofInt = function(x) {
     return x.toString();
 }

--- a/examples/capabilities/SealerUnsealer.wyv
+++ b/examples/capabilities/SealerUnsealer.wyv
@@ -5,7 +5,6 @@ require stdout
 import wyvern.option
 import wyvern.collections.map
 import wyvern.collections.list
-import wyvern.String
 
 // This example would be a lot nicer if parameterised Option[T]
 // worked! Will rewrite when this bug is fixed. :-)
@@ -51,7 +50,7 @@ resource type SealerUnsealer
      var unsealer:Unsealer
 
 def makeSealerUnsealer():SealerUnsealer
-    var map:Map = map.make((b1:Box,b2:Box) => String.equals(b1.name,b2.name))
+    var map:Map = map.make((b1:Box,b2:Box) => b1.name.equals(b2.name))
     var currentKey:String = "S"
     new
         var sealer:Sealer = new

--- a/examples/introductory/algebra.wyv
+++ b/examples/introductory/algebra.wyv
@@ -170,7 +170,7 @@ def toString(t : Term) : String
 
 def d(wrt : String, t : Term) : Term = match t:
   t:Constant => Constant(0.0)
-  t:Variable => if (String.equals(t.name, wrt))
+  t:Variable => if (wrt.equals(t.name))
                   Constant(1.0)
                  else
                   Constant(0.0)
@@ -466,7 +466,7 @@ def printInfo(t : Term, xVal : Number, yVal : Number) : Unit
   val xString : String = numberToString(xVal)
   val yString : String = numberToString(yVal)
 
-  var bindings : Map = map.make((x : String, y : String) => String.equals(x, y))
+  var bindings : Map = map.make((x : String, y : String) => x.equals(y))
   bindings.put("x", xVal)
   bindings.put("y", yVal)
 

--- a/stdlib/platform/java/wyvern/String.wyv
+++ b/stdlib/platform/java/wyvern/String.wyv
@@ -20,6 +20,3 @@ def ofFormattedFloat(format : String, f : Float) : String
 
 def ofCharacter(c : Character) : String
     utils.ofCharacter(c)
-
-def concatenate(s1:String,s2:String): String
-    utils.concatenate(s1,s2)

--- a/stdlib/platform/java/wyvern/String.wyv
+++ b/stdlib/platform/java/wyvern/String.wyv
@@ -2,9 +2,6 @@ module String
 
 import java:wyvern.stdlib.support.StringHelper.utils
 
-def equals(str1:String,str2:String):Boolean
-    utils.testEqual(str1,str2)
-
 def ofInt(x : Int) : String
     utils.ofInt(x)
 

--- a/stdlib/wyvern/String.wyt
+++ b/stdlib/wyvern/String.wyt
@@ -8,5 +8,3 @@ type String
   def ofFormattedFloat(format : String, f : Float) : String
 
   def ofCharacter(c : Character) : String
-
-  def concatenate(s1:String,s2:String) : String 

--- a/stdlib/wyvern/String.wyt
+++ b/stdlib/wyvern/String.wyt
@@ -1,6 +1,4 @@
 type String
-  def equals(str1:String,str2:String):Boolean
-
   def ofInt(x : Int) : String
 
   def ofFloat(f : Float) : String

--- a/tools/src/wyvern/stdlib/Globals.java
+++ b/tools/src/wyvern/stdlib/Globals.java
@@ -173,8 +173,12 @@ public final class Globals {
         boolDeclTypes.add(new DefDeclType("&&", Util.booleanType(), Arrays.asList(new FormalArg("other", Util.booleanType()))));
         boolDeclTypes.add(new DefDeclType("||", Util.booleanType(), Arrays.asList(new FormalArg("other", Util.booleanType()))));
         boolDeclTypes.add(new DefDeclType("!", Util.booleanType(), Arrays.asList()));
+
         // construct a type for the system object
+        // N.B.: Operations here are built-in and performed on an instance of a type.
+        // Static operations must be placed into a Wyvern module for that type.
         List<DeclType> declTypes = new LinkedList<DeclType>();
+
         List<DeclType> intDeclTypes = new LinkedList<DeclType>();
         intDeclTypes.add(new DefDeclType("+", Util.intType(), Arrays.asList(new FormalArg("other", Util.intType()))));
         intDeclTypes.add(new DefDeclType("-", Util.intType(), Arrays.asList(new FormalArg("other", Util.intType()))));
@@ -237,7 +241,6 @@ public final class Globals {
         NominalType systemJavaScript = new NominalType("this", "JavaScript");
         ExtensibleTagType javascriptType = new ExtensibleTagType(systemPlatform, Util.unitType(), systemJavaScript, null);
         declTypes.add(new ConcreteTypeMember("JavaScript", javascriptType));
-        //declTypes.add(new AbstractTypeMember("Python"));
         List<DeclType> pyDeclTypes = new LinkedList<DeclType>();
         pyDeclTypes.add(new DefDeclType("toString", Util.stringType(), Arrays.asList(new FormalArg("other", Util.dynType()))));
         pyDeclTypes.add(new DefDeclType("isEqual", Util.booleanType(),
@@ -245,7 +248,6 @@ public final class Globals {
         ValueType pythonType = new StructuralType("Python", pyDeclTypes);
         NominalType systemPython = new NominalType("this", "Java");
         ExtensibleTagType pythonTagType = new ExtensibleTagType(systemPlatform, pythonType, systemPython, null);
-        //declTypes.add(new ConcreteTypeMember("Python", pythonType));
         declTypes.add(new ConcreteTypeMember("Python", pythonTagType));
         declTypes.add(new AbstractTypeMember("Context"));
         declTypes.add(new ValDeclType("unit", Util.unitType()));

--- a/tools/src/wyvern/stdlib/Globals.java
+++ b/tools/src/wyvern/stdlib/Globals.java
@@ -102,7 +102,7 @@ public final class Globals {
         }
         return s.getResolver().getPreludeIfPresent();
     }
-    
+
     public static SeqExpr getPrelude() {
         if (!usePrelude) {
             SeqExpr result = new SeqExpr();
@@ -210,6 +210,7 @@ public final class Globals {
         stringDeclTypes.add(new DefDeclType("<", Util.booleanType(), Arrays.asList(new FormalArg("other", Util.stringType()))));
         stringDeclTypes.add(new DefDeclType(">", Util.booleanType(), Arrays.asList(new FormalArg("other", Util.stringType()))));
         stringDeclTypes.add(new DefDeclType("+", Util.stringType(), Arrays.asList(new FormalArg("other", Util.stringType()))));
+        stringDeclTypes.add(new DefDeclType("equals", Util.booleanType(), Arrays.asList(new FormalArg("other", Util.stringType()))));
         stringDeclTypes.add(new DefDeclType("charAt", Util.charType(), Arrays.asList(new FormalArg("index", Util.intType()))));
         stringDeclTypes.add(new DefDeclType("length", Util.intType(), new LinkedList<FormalArg>()));
         stringDeclTypes.add(new DefDeclType("substring", Util.stringType(),

--- a/tools/src/wyvern/stdlib/Globals.java
+++ b/tools/src/wyvern/stdlib/Globals.java
@@ -215,11 +215,12 @@ public final class Globals {
         stringDeclTypes.add(new DefDeclType(">", Util.booleanType(), Arrays.asList(new FormalArg("other", Util.stringType()))));
         stringDeclTypes.add(new DefDeclType("+", Util.stringType(), Arrays.asList(new FormalArg("other", Util.stringType()))));
         stringDeclTypes.add(new DefDeclType("equals", Util.booleanType(), Arrays.asList(new FormalArg("other", Util.stringType()))));
-        stringDeclTypes.add(new DefDeclType("charAt", Util.charType(), Arrays.asList(new FormalArg("index", Util.intType()))));
         stringDeclTypes.add(new DefDeclType("length", Util.intType(), new LinkedList<FormalArg>()));
+        stringDeclTypes.add(new DefDeclType("charAt", Util.charType(), Arrays.asList(new FormalArg("index", Util.intType()))));
         stringDeclTypes.add(new DefDeclType("substring", Util.stringType(),
                 Arrays.asList(new FormalArg[]{new FormalArg("start", Util.intType()), new FormalArg("end", Util.intType())})));
         stringDeclTypes.add(new DefDeclType("concat", Util.stringType(), Arrays.asList(new FormalArg("other", Util.stringType()))));
+        stringDeclTypes.add(new DefDeclType("indexOf", Util.intType(), Arrays.asList(new FormalArg("ch", Util.intType()))));
         ValueType stringType = new StructuralType("stringSelf", stringDeclTypes);
         declTypes.add(new ConcreteTypeMember("String", stringType));
 

--- a/tools/src/wyvern/stdlib/support/StringHelper.java
+++ b/tools/src/wyvern/stdlib/support/StringHelper.java
@@ -16,16 +16,12 @@ public class StringHelper {
     public String ofFloat(double d) {
         return Double.toString(d);
     }
-    
+
     public String ofFormattedFloat(String format, double d) {
         return String.format(format, d);
     }
 
     public String ofCharacter(char c) {
         return "" + c;
-    }
-
-    public String concatenate(String s1, String s2) {
-        return s1 + "" + s2;
     }
 }

--- a/tools/src/wyvern/stdlib/support/StringHelper.java
+++ b/tools/src/wyvern/stdlib/support/StringHelper.java
@@ -22,6 +22,6 @@ public class StringHelper {
     }
 
     public String ofCharacter(char c) {
-        return "" + c;
+        return String.valueOf(c);
     }
 }

--- a/tools/src/wyvern/target/corewyvernIL/expression/StringLiteral.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/StringLiteral.java
@@ -102,6 +102,7 @@ public class StringLiteral extends Literal implements Invokable {
         case "charAt": return new CharacterLiteral(value.charAt(((IntegerLiteral) args.get(0)).getValue()));
         case "substring": return new StringLiteral(value.substring(((IntegerLiteral) args.get(0)).getValue(), ((IntegerLiteral) args.get(1)).getValue()));
         case "concat": return new StringLiteral(value.concat(((StringLiteral) args.get(0)).getValue()));
+        case "indexOf": return new IntegerLiteral(value.indexOf(((IntegerLiteral) args.get(0)).getValue()));
         default: throw new RuntimeException("runtime error: string operation " + methodName + "not supported by the runtime");
         }
     }

--- a/tools/src/wyvern/target/corewyvernIL/expression/StringLiteral.java
+++ b/tools/src/wyvern/target/corewyvernIL/expression/StringLiteral.java
@@ -36,7 +36,7 @@ public class StringLiteral extends Literal implements Invokable {
 
     @Override
     public int hashCode() {
-        return this.value.hashCode();
+        return value.hashCode();
     }
 
     @Override
@@ -52,7 +52,7 @@ public class StringLiteral extends Literal implements Invokable {
         }
         try {
             StringLiteral other = (StringLiteral) obj;
-            return this.getValue().equals(other.getValue());
+            return getValue().equals(other.getValue());
         } catch (ClassCastException e) {
             return false;
         }
@@ -90,16 +90,18 @@ public class StringLiteral extends Literal implements Invokable {
         return Util.stringType();
     }
 
+    @Override
     public Value invoke(String methodName, List<Value> args, FileLocation loc) {
         switch (methodName) {
-        case "<": return new BooleanLiteral(this.value.compareTo(((StringLiteral) args.get(0)).getValue()) < 0);
-        case ">": return new BooleanLiteral(this.value.compareTo(((StringLiteral) args.get(0)).getValue()) > 0);
-        case "==": return new BooleanLiteral(this.value.compareTo(((StringLiteral) args.get(0)).getValue()) == 0);
-        case "+": return new StringLiteral(this.value + ((StringLiteral) args.get(0)).getValue());
-        case "length": return new IntegerLiteral(this.value.length());
-        case "charAt": return new CharacterLiteral(this.value.charAt(((IntegerLiteral) args.get(0)).getValue()));
-        case "substring": return new StringLiteral(this.value.substring(((IntegerLiteral) args.get(0)).getValue(), ((IntegerLiteral) args.get(1)).getValue()));
-        case "concat": return new StringLiteral(this.value.concat(((StringLiteral) args.get(0)).getValue()));
+        case "<": return new BooleanLiteral(value.compareTo(((StringLiteral) args.get(0)).getValue()) < 0);
+        case ">": return new BooleanLiteral(value.compareTo(((StringLiteral) args.get(0)).getValue()) > 0);
+        case "==": return new BooleanLiteral(value.compareTo(((StringLiteral) args.get(0)).getValue()) == 0);
+        case "+": return new StringLiteral(value + ((StringLiteral) args.get(0)).getValue());
+        case "equals": return new BooleanLiteral(value.equals(((StringLiteral) args.get(0)).getValue()));
+        case "length": return new IntegerLiteral(value.length());
+        case "charAt": return new CharacterLiteral(value.charAt(((IntegerLiteral) args.get(0)).getValue()));
+        case "substring": return new StringLiteral(value.substring(((IntegerLiteral) args.get(0)).getValue(), ((IntegerLiteral) args.get(1)).getValue()));
+        case "concat": return new StringLiteral(value.concat(((StringLiteral) args.get(0)).getValue()));
         default: throw new RuntimeException("runtime error: string operation " + methodName + "not supported by the runtime");
         }
     }

--- a/tools/src/wyvern/tools/tests/errors/ReturnTypeBug.wyv
+++ b/tools/src/wyvern/tools/tests/errors/ReturnTypeBug.wyv
@@ -22,7 +22,6 @@ module capabilities
 
 import wyvern.option
 import wyvern.collections.map
-import wyvern.String
 
 // This example would be a lot nicer if parameterised Option[T]
 // worked! Will rewrite when this bug is fixed. :-)
@@ -46,7 +45,7 @@ resource type SealerUnsealer
      var unsealer:Unsealer
 
 def make():SealerUnsealer
-    var map:Map = map.make((s1:Dyn,s2:Dyn) => String.equals(s1,s2))
+    var map:Map = map.make((s1:String,s2:String) => s1.equals(s2))
     new
         var sealer:Sealer = new
             def seal(object:Option):String

--- a/tools/src/wyvern/tools/tests/webarch/database.wyv
+++ b/tools/src/wyvern/tools/tests/webarch/database.wyv
@@ -2,7 +2,6 @@ module database
 
 import wyvern.option
 import wyvern.collections.map
-import wyvern.String
 
 type Option = option.Option
 
@@ -12,7 +11,7 @@ resource type KeyVal
 
 // currently the actual implementation ignores the dbFilePath, but it's useful for thinking about deployment properties.  Need to implement it soon.
 def make(dbFilePath:String):KeyVal = new
-	val entries = map.make((s1:Dyn,s2:Dyn) => String.equals(s1,s2))
+	val entries = map.make((s1:String,s2:String) => s1.equals(s2))
 	def get(key:String):Option[String] = this.entries.get(key)
 	def put(key:String, value:String):Unit
 		this.entries.put(key,value)


### PR DESCRIPTION
Non-static `String` operations should be built-in, i.e. be implemented in [Globals.java](https://github.com/wyvernlang/wyvern/blob/7c795a39245a906c04606b67e7b29294b690dc05/tools/src/wyvern/stdlib/Globals.java) and [StringLiteral.java](https://github.com/wyvernlang/wyvern/blob/7c795a39245a906c04606b67e7b29294b690dc05/tools/src/wyvern/target/corewyvernIL/expression/StringLiteral.java). Static `String` operations should be in a Wyvern module, such as [String.wyv](https://github.com/wyvernlang/wyvern/blob/7c795a39245a906c04606b67e7b29294b690dc05/stdlib/platform/java/wyvern/String.wyv) and [String.wyt](https://github.com/wyvernlang/wyvern/blob/7c795a39245a906c04606b67e7b29294b690dc05/stdlib/wyvern/String.wyt).