### PR TITLE
Extensible text-editor application with four plugins

### DIFF
--- a/examples/text-editor/JFrame.wyt
+++ b/examples/text-editor/JFrame.wyt
@@ -1,0 +1,2 @@
+type JFrame
+  def setTitle(title: String): Unit

--- a/examples/text-editor/JTextArea.wyt
+++ b/examples/text-editor/JTextArea.wyt
@@ -1,0 +1,2 @@
+type JTextArea
+  def getText(): String

--- a/examples/text-editor/Logger.wyt
+++ b/examples/text-editor/Logger.wyt
@@ -1,0 +1,2 @@
+resource type Logger
+  def updateLog(msg: String): Unit

--- a/examples/text-editor/NativeActionCreator.wyt
+++ b/examples/text-editor/NativeActionCreator.wyt
@@ -1,0 +1,3 @@
+type NativeActionCreator
+  def create(s: String): Unit
+  def createWithAction(s: String, f: Unit -> Unit): Unit

--- a/examples/text-editor/NativeJOptionPane.wyt
+++ b/examples/text-editor/NativeJOptionPane.wyt
@@ -1,0 +1,7 @@
+type NativeJOptionPane
+  def showMessageDialog(message: String, title: String, messageType: Int): Unit
+  def showConfirmDialog(message: String, title: String, optionType: Int): Unit
+  def getPlainMessageValue(): Int
+  def getErrorMessageValue(): Int
+  def getYesNoOptionValue(): Int
+  def getYesOptionValue(): Int

--- a/examples/text-editor/NativeUIManager.wyt
+++ b/examples/text-editor/NativeUIManager.wyt
@@ -1,0 +1,7 @@
+type NativeUIManager
+  def paintUIAttributeBlack(element: String, attribute: String): Unit
+  def paintUIAttributeDarkGray(element: String, attribute: String): Unit
+  def paintUIAttributeGray(element: String, attribute: String): Unit
+  def paintUIAttributeLightGray(element: String, attribute: String): Unit
+  def paintUIAttributeWhite(element: String, attribute: String): Unit
+  def updateLookAndFeel(jFrame: Dyn): Unit // FIX: Substitute Dyn with JFrame type. Currently gives an error.

--- a/examples/text-editor/Plugin.wyt
+++ b/examples/text-editor/Plugin.wyt
@@ -1,0 +1,3 @@
+resource type Plugin // this type is a resource because plugins 1) may have fields and 2) may need some resources to be passed in
+  def getName(): String
+  def run(): Unit

--- a/examples/text-editor/README.md
+++ b/examples/text-editor/README.md
@@ -1,0 +1,22 @@
+# This is an extensible text-editor application.
+
+## Running the application
+
+To start the application, run the following command:
+
+```
+wyvern path/to/main.wyv
+```
+
+## Adding a plugin
+
+The plugin must be of type `Plugin`.
+
+To add a plugin:
+1. Add the plugin file (`.wyv` file) to the `plugins` folder.
+2. Make changes to the `textEditor.wyv` file in the areas marked with asterisks and labeled with numbered steps:
+  * Step 1: Import the plugin.
+  * Step 2: Instantiate the plugin passing in appropriate resources.
+  * Step 3: Register plugin with menu or run it on setup.
+    - Register a plugin with the menu so that the user can activate it on demand during the text-editor execution. (Registered plugins are usually those that depend on the user's input, e.g., a plugin that counts the number of words in the opened file.)
+    - Make the plugin run once on setup. (Plugins that are run on setup are usually those that set a configuration for the text editor, e.g., a plugin that sets the text editor's theme.)

--- a/examples/text-editor/TextEditor.wyt
+++ b/examples/text-editor/TextEditor.wyt
@@ -1,0 +1,14 @@
+import Plugin
+resource type TextEditor
+  def run(): Unit
+  def saveFile(fileName: String): Unit // N.B.: File exceptions aren't handled.
+  def saveFileAs(): Unit
+  def saveOld(): Unit
+  def performNewAction(): Unit
+  def performSaveAction(): Unit
+  def performSaveAsAction(): Unit
+  def performOpenAction(): Unit // N.B.: File exceptions aren't handled.
+  def performQuitAction(): Unit
+  def performKeyPressedAction(): Unit
+  def registerPlugin(plugin: Plugin): Unit
+  def runPluginOnSetup(plugin: Plugin): Unit

--- a/examples/text-editor/log.txt
+++ b/examples/text-editor/log.txt
@@ -1,0 +1,39 @@
+New text-editor window is starting.
+Registered plugin Word Count.
+Registered plugin Questionnaire Creator.
+Running plugin Dark Theme...
+Set text editor theme to dark.
+Ran plugin Dark Theme.
+New text-editor window started.
+Running the Word Count plugin...
+Result: The document contains 0 words.
+File /Users/dkurilov/workspace/wyvern/examples/text-editor/JFrame.wyt was opened.
+New text-editor window is starting.
+Registered plugin Word Count.
+Registered plugin Questionnaire Creator.
+Running plugin Dark Theme...
+Set text editor theme to dark.
+Ran plugin Dark Theme.
+New text-editor window started.
+New text editor was created.
+Running the Questionnaire Creator plugin...
+Result: The created questionnaire is:
+Alia wisi prodesset vel ei, appetere platonem honestatis vix ut?
+Vis ex sonet alterum?
+File was saved as /Users/dkurilov/workspace/wyvern/examples/text-editor/tmp.txt.
+File was saved as /Users/dkurilov/workspace/wyvern/examples/text-editor/tmp2.txt.
+Closing text editor...
+New text-editor window is starting.
+Registered plugin Word Count.
+Registered plugin Questionnaire Creator.
+Running plugin Dark Theme...
+Set text editor theme to dark.
+Ran plugin Dark Theme.
+New text-editor window started.
+New text-editor window is starting.
+Registered plugin Word Count.
+Registered plugin Questionnaire Creator.
+Running plugin Dark Theme...
+Set text editor theme to dark.
+Ran plugin Dark Theme.
+New text-editor window started.

--- a/examples/text-editor/logger.wyv
+++ b/examples/text-editor/logger.wyv
@@ -1,0 +1,11 @@
+module def logger(logFile: fileSystem.File): Logger
+// N.B.: Alternatively, this module could be pure and the updateLog method would take the log file as an argument.
+// This way is more secure because the alternative way requires plugins to have an instance of the log file, 
+// which allowS more operations on the log file than just updating it.
+
+def updateLog(msg: String): Unit
+  // Opening and closing the log file is necessary to be able to handle several text-editor windows, each of which is a text-editor instance.
+  // This also allows the log file to be written when quitting the text editor with a shortcut.
+  val logAppender = logFile.makeAppender()
+  logAppender.write(msg)
+  logAppender.close()

--- a/examples/text-editor/main.wyv
+++ b/examples/text-editor/main.wyv
@@ -1,0 +1,16 @@
+require java
+
+import fileSystem
+import logger
+import textEditor
+import TextEditor
+
+val fs = fileSystem(java)
+val logFile = fs.makeFile("log.txt") // We create the log file, but not an appender for it to be able to handle several text-editor windows, each of which is a text-editor instance.
+val logger = logger(logFile)
+
+def createTextEditorInstance(): TextEditor
+  textEditor(java, logger, () => createTextEditorInstance())
+
+val te = createTextEditorInstance()
+te.run()

--- a/examples/text-editor/plugins/darkTheme.wyv
+++ b/examples/text-editor/plugins/darkTheme.wyv
@@ -1,0 +1,17 @@
+module def darkTheme(logger: Logger, nativeUIManager: NativeUIManager, jFrame: JFrame): Plugin
+// N.B.: In Java, once the theme is changed, apparently, there is no way to change it again, so this plugin shouldn't be registered in the menu.
+
+def getName(): String
+  "Dark Theme"
+
+def run(): Unit
+  nativeUIManager.paintUIAttributeGray("MenuBar", "background")
+  nativeUIManager.paintUIAttributeDarkGray("MenuItem", "background")
+  nativeUIManager.paintUIAttributeWhite("MenuItem", "foreground")
+  nativeUIManager.paintUIAttributeDarkGray("TextArea", "background")
+  nativeUIManager.paintUIAttributeWhite("TextArea", "foreground")
+  nativeUIManager.paintUIAttributeWhite("TextArea", "caretForeground")
+  nativeUIManager.paintUIAttributeGray("ScrollPane", "background")
+  nativeUIManager.paintUIAttributeDarkGray("ScrollBar", "background")
+  nativeUIManager.updateLookAndFeel(jFrame)
+  logger.updateLog("Set text editor theme to dark.\n")

--- a/examples/text-editor/plugins/lightTheme.wyv
+++ b/examples/text-editor/plugins/lightTheme.wyv
@@ -1,0 +1,16 @@
+module def lightTheme(logger: Logger, nativeUIManager: NativeUIManager, jFrame: JFrame): Plugin
+// N.B.: In Java, once the theme is changed, apparently, there is no way to change it again, so this plugin shouldn't be registered in the menu.
+
+def getName(): String
+  "Light Theme"
+
+def run(): Unit
+  nativeUIManager.paintUIAttributeWhite("MenuBar", "background")
+  nativeUIManager.paintUIAttributeWhite("MenuItem", "background")
+  nativeUIManager.paintUIAttributeBlack("MenuItem", "foreground")
+  nativeUIManager.paintUIAttributeWhite("TextArea", "background")
+  nativeUIManager.paintUIAttributeBlack("TextArea", "foreground")
+  nativeUIManager.paintUIAttributeWhite("ScrollPane", "background")
+  nativeUIManager.paintUIAttributeWhite("ScrollBar", "background")
+  nativeUIManager.updateLookAndFeel(jFrame)
+  logger.updateLog("Set text editor theme to light.\n")

--- a/examples/text-editor/plugins/questionnaireCreator.wyv
+++ b/examples/text-editor/plugins/questionnaireCreator.wyv
@@ -1,0 +1,64 @@
+module def questionnaireCreator(logger: Logger, textArea: JTextArea, fs: fileSystem.FileSystem): Plugin
+// N.B.: Must pass in JTextArea and not just String because need to get the latest version of the text.
+
+def getName(): String
+  "Questionnaire Creator"
+
+def run(): Unit
+  logger.updateLog("Running the " + getName() + " plugin...\n")
+  val text = textArea.getText()
+  val length = text.length()
+  var questionnaire: String = ""
+  var questionnaire: String = ""
+  if (length > 0)
+    questionnaire = extractQuestions(text, "")
+  val fileName = "questionnaire.txt"
+  val fileWriter = fs.makeFile(fileName).makeWriter()
+  fileWriter.write(questionnaire)
+  fileWriter.close()
+  logger.updateLog("Result: The created questionnaire is:\n" + questionnaire)
+
+
+def extractQuestions(text: String, result: String): String
+  val length = text.length()
+  if (length < 1)
+      result
+    else
+      val questionMarkPosition = text.indexOf(63) // 63 is '?'
+      if (questionMarkPosition == -1)
+          result
+        else
+          val periodPosition = text.indexOf(46) // 46 is '.'
+          val exclamationPointPosition = text.indexOf(33) // 33 is '!'
+          if ((periodPosition > questionMarkPosition && exclamationPointPosition > questionMarkPosition) || (periodPosition == -1 && exclamationPointPosition == -1))
+              extractQuestions(text.substring(questionMarkPosition + 1, length), result + trimSpaces(text.substring(0, questionMarkPosition + 1)) + "\n")
+            else
+              if (periodPosition < questionMarkPosition && exclamationPointPosition < questionMarkPosition)
+                  var largerPosition: Int = periodPosition
+                  if (periodPosition < exclamationPointPosition)
+                      largerPosition = exclamationPointPosition
+                  extractQuestions(text.substring(largerPosition + 1, length), result)
+                else
+                  var smallerPosition: Int = periodPosition
+                  if (periodPosition > exclamationPointPosition)
+                      smallerPosition = exclamationPointPosition
+                  if (smallerPosition == -1)
+                      extractQuestions(text.substring(questionMarkPosition + 1, length), result + trimSpaces(text.substring(0, questionMarkPosition + 1)) + "\n")
+                    else
+                      extractQuestions(text.substring(smallerPosition + 1, length), result)
+
+def trimSpaces(text: String): String
+  var changed: Boolean = false
+  var firstIndex: Int = 0
+  if (text.charAt(0) == #" " || text.charAt(0) == #"\n" || text.charAt(0) == #"\t")
+    firstIndex = 1
+    changed = true
+  var lastIndex: Int = text.length()
+  if (text.charAt(lastIndex - 1) == #" " || text.charAt(lastIndex - 1) == #"\n" || text.charAt(lastIndex - 1) == #"\t")
+    lastIndex = text.length() - 1
+    changed = true
+  if (changed)
+      trimSpaces(text.substring(firstIndex, lastIndex))
+    else
+      text.substring(firstIndex, lastIndex)
+

--- a/examples/text-editor/plugins/wordCount.wyv
+++ b/examples/text-editor/plugins/wordCount.wyv
@@ -1,0 +1,39 @@
+module def wordCount(logger: Logger, textArea: JTextArea, nativeJOptionPane: NativeJOptionPane): Plugin
+// N.B.: Must pass in JTextArea and not just String because need to get the latest version of the text.
+
+import wyvern.String
+
+def getName(): String
+  "Word Count"
+
+def run(): Unit
+  logger.updateLog("Running the " + getName() + " plugin...\n")
+  val text = textArea.getText()
+  val length = text.length()
+  var result: Int = 0
+  if (length > 0)
+    result = countWords(text, length - 1, true, 0)
+  var word: String = " words.\n"
+  if (result == 1)
+      word = " word.\n"
+  nativeJOptionPane.showMessageDialog("The document contains " + String.valueOf(result) + word, "Word Count", nativeJOptionPane.getPlainMessageValue())
+  logger.updateLog("Result: The document contains " + String.valueOf(result) + word)
+
+
+def countWords(text: String, currentPosition: Int, prevCharWasSpace: Boolean, result: Int): Int
+  if (currentPosition == -1)
+      result
+    else
+      if (text.charAt(currentPosition) == #" ")
+          countWords(text, currentPosition - 1, true, result)
+        else
+          if (text.charAt(currentPosition) == #"\n")
+              countWords(text, currentPosition - 1, true, result)
+            else
+              if (text.charAt(currentPosition) == #"\t")
+                  countWords(text, currentPosition - 1, true, result)
+                else
+                  if (prevCharWasSpace)
+                      countWords(text, currentPosition - 1, false, result + 1)
+                    else
+                      countWords(text, currentPosition - 1, false, result)

--- a/examples/text-editor/textEditor.wyv
+++ b/examples/text-editor/textEditor.wyv
@@ -1,0 +1,175 @@
+module def textEditor(java: Java, logger: Logger, createTextEditorInstance: Dyn): TextEditor
+// FIX: Use the arrow type instead of Dyn. Currently gives the cast error: can't cast Arrow into NamedType
+
+import java:wyvern.stdlib.support.TextEditorHelper.nativeJTextArea
+import java:wyvern.stdlib.support.TextEditorHelper.nativeJFileChooser
+import java:wyvern.stdlib.support.TextEditorHelper.nativeJScrollPane
+import java:wyvern.stdlib.support.TextEditorHelper.nativeJFrame
+import java:wyvern.stdlib.support.TextEditorHelper.nativeJMenuBar
+import java:wyvern.stdlib.support.TextEditorHelper.nativeJMenu
+import java:wyvern.stdlib.support.TextEditorHelper.nativeJOptionPane
+import java:wyvern.stdlib.support.TextEditorHelper.nativeUtils
+import java:wyvern.stdlib.support.TextEditorHelper.nativeActionCreator
+import java:wyvern.stdlib.support.TextEditorHelper.nativeKeyListenerCreator
+import java:wyvern.stdlib.support.TextEditorHelper.nativeUIManager
+
+import fileSystem
+import fileSystem.Reader
+import fileSystem.Writer
+import Plugin
+
+/******* Step 1: Import plugins *********************************************/
+
+import plugins.wordCount
+import plugins.darkTheme
+import plugins.lightTheme
+import plugins.questionnaireCreator
+
+/****************************************************************************/
+
+nativeUIManager.enableSettingLookAndFeel() // This must happen before jFrame is created.
+val jFrame = nativeJFrame.create()
+val textArea = nativeJTextArea.create(20, 60)
+val dialog = nativeJFileChooser.create(nativeUtils.getSystemProperty("user.dir"))
+var currentFile: String = "Untitled"
+var changed: Boolean = false
+val scroll = nativeJScrollPane.create(textArea, nativeJScrollPane.getVerticalScrollbarAlwaysValue(), nativeJScrollPane.getHorizontalScrollbarAlwaysValue())
+val jmb = nativeJMenuBar.create()
+val file = nativeJMenu.create("File")
+val edit = nativeJMenu.create("Edit")
+val plugins = nativeJMenu.create("Plugins")
+val fs = fileSystem(java)
+val save = nativeActionCreator.create("Save")
+
+def registerPlugin(plugin: Plugin): Unit
+  plugins.add(nativeActionCreator.createWithAction(plugin.getName(), () => plugin.run()))
+  logger.updateLog("Registered plugin " + plugin.getName() + ".\n")
+
+def runPluginOnSetup(plugin: Plugin): Unit
+  logger.updateLog("Running plugin " + plugin.getName() + "...\n")
+  plugin.run()
+  logger.updateLog("Ran plugin " + plugin.getName() + ".\n")
+
+def saveFile(fileName: String): Unit // N.B.: File exceptions aren't handled.
+  val fileWriter = fs.makeFile(fileName).makeWriter()
+  fileWriter.write(textArea.getText())
+  fileWriter.close()
+  logger.updateLog("File was saved as " + fileName + ".\n")
+  currentFile = fileName
+  jFrame.setTitle(currentFile)
+  changed = false
+  save.setEnabled(false)
+
+def saveFileAs(): Unit
+  if (dialog.showSaveDialog(nativeUtils.getNullValue()) == nativeJFileChooser.getApproveOption())
+    saveFile(dialog.getSelectedFile().getAbsolutePath())
+
+def saveOld(): Unit
+  if (changed)
+    if (nativeJOptionPane.showConfirmDialog("Would you like to save " + currentFile + " ?", "Save", nativeJOptionPane.getYesNoOptionValue()) == nativeJOptionPane.getYesOptionValue())
+      saveFile(currentFile)
+
+def performNewAction(): Unit
+  createTextEditorInstance().run()
+  logger.updateLog("New text editor was created.\n")
+
+def performSaveAction(): Unit
+  if ("Untitled".equals(currentFile))
+      saveFileAs()
+    else
+      saveFile(currentFile)
+
+def performSaveAsAction(): Unit
+  saveFileAs()
+
+val saveAs = nativeActionCreator.createWithAction("Save as...", () => performSaveAsAction())
+
+def performOpenAction(): Unit // N.B.: File exceptions aren't handled.
+  saveOld()
+  if (dialog.showOpenDialog(nativeUtils.getNullValue()) == nativeJFileChooser.getApproveOption())
+    val fileName = dialog.getSelectedFile().getAbsolutePath()
+    val fileReader = fs.makeFile(fileName).makeReader()
+    textArea.setText(fileReader.readFully())
+    fileReader.close()
+    currentFile = fileName
+    jFrame.setTitle(currentFile)
+    changed = false
+    logger.updateLog("File " + fileName + " was opened.\n")
+  saveAs.setEnabled(true)
+
+def performQuitAction(): Unit
+  saveOld()
+  logger.updateLog("Closing text editor...\n")
+  nativeUtils.exitSystem()
+
+val newFile = nativeActionCreator.createWithAction("New", () => performNewAction())
+val open = nativeActionCreator.createWithAction("Open", () => performOpenAction())
+save.setAction(() => performSaveAction())
+val quit = nativeActionCreator.createWithAction("Quit", () => performQuitAction())
+
+def performKeyPressedAction(): Unit
+  changed = true
+  save.setEnabled(true)
+  saveAs.setEnabled(true)
+
+val kl = nativeKeyListenerCreator.create(() => performKeyPressedAction())
+val m = textArea.getActionMap()
+
+def run(): Unit
+  logger.updateLog("New text-editor window is starting...\n")
+  jFrame.add(scroll, "Center") // "Center" = BorderLayout.CENTER
+  jFrame.setJMenuBar(jmb)
+
+  jmb.add(file)
+  jmb.add(edit)
+  jmb.add(plugins)
+
+  file.add(newFile)
+  file.add(open)
+  file.add(save)
+  file.add(saveAs)
+  file.add(quit)
+
+  // FIX? There is a bug that if the content of the file is simply pasted from
+  // the clipboard right after the file is open, the save options are
+  // disabled, and so the file can't be saved unless it is manually modified.
+  edit.add(m.get("cut-to-clipboard")) // "cut-to-clipboard" = DefaultEditorKit.cutAction
+  edit.add(m.get("copy-to-clipboard")) // "copy-to-clipboard" = DefaultEditorKit.copyAction
+  edit.add(m.get("paste-from-clipboard")) // "paste-from-clipboard" = DefaultEditorKit.pasteAction
+
+  edit.getItem(0).setText("Cut")
+  edit.getItem(1).setText("Copy")
+  edit.getItem(2).setText("Paste")
+
+  save.setEnabled(false)
+  saveAs.setEnabled(false)
+
+/******* Step 2: Instantiate plugins passing in appropriate resources *******/
+
+  val darkTheme = darkTheme(logger, nativeUIManager, jFrame)
+  val lightTheme = lightTheme(logger, nativeUIManager, jFrame)
+  val wordCount = wordCount(logger, textArea, nativeJOptionPane) // Must pass in JTextArea and not just String because need to get the latest version of the text
+  val questionnaireCreator = questionnaireCreator(logger, textArea, fs) // Must pass in JTextArea and not just String because need to get the latest version of the text
+
+/****************************************************************************/
+
+//******* Step 3: Register plugins with menu or run them on setup ***********/
+
+  // Register plugins to be displayed in the menu so that the user can activate them on demand during the execution
+  registerPlugin(wordCount)
+  registerPlugin(questionnaireCreator)
+
+  // Run plugins that should be run once on setup
+  // Choose a theme: In Java, once the theme is changed, apparently, there is no way to change it again,
+  // so only one theme can be used at a time.
+  runPluginOnSetup(darkTheme)
+  //runPluginOnSetup(lightTheme)
+
+/****************************************************************************/
+
+  jFrame.setDefaultCloseOperation(nativeJFrame.getExitOnClose())
+  jFrame.pack()
+  textArea.addKeyListener(kl)
+  jFrame.setTitle(currentFile)
+  jFrame.setVisible(true)
+  logger.updateLog("New text-editor window started.\n")

--- a/tools/src/wyvern/stdlib/support/TextEditorHelper.java
+++ b/tools/src/wyvern/stdlib/support/TextEditorHelper.java
@@ -1,0 +1,227 @@
+package wyvern.stdlib.support;
+
+import java.awt.Color;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.util.LinkedList;
+
+import javax.swing.AbstractAction;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JOptionPane;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
+import wyvern.target.corewyvernIL.expression.ObjectValue;
+import wyvern.target.corewyvernIL.expression.Value;
+
+public final class TextEditorHelper {
+    private TextEditorHelper() { }
+
+    public static final NativeUtils nativeUtils = new NativeUtils();
+    public static class NativeUtils {
+        public Object getNullValue() {
+            return null;
+        }
+        public String getSystemProperty(String s) {
+            return System.getProperty(s);
+        }
+        public void exitSystem() {
+            System.exit(0);
+        }
+    }
+
+    public static final NativeUIManager nativeUIManager = new NativeUIManager();
+    public static class NativeUIManager {
+        public void enableSettingLookAndFeel() {
+            try {
+                UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());
+            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
+                    | UnsupportedLookAndFeelException e) {
+                System.err.println("Error setting look and feel: " + e.getMessage());
+                e.printStackTrace();
+            }
+        }
+        public void setUIProperty(String element, String attribute, Color color) {
+            UIManager.put(element + "." + attribute, color);
+        }
+        public void paintUIAttributeBlack(String element, String attribute) {
+            UIManager.put(element + "." + attribute, Color.BLACK);
+        }
+        public void paintUIAttributeBlue(String element, String attribute) {
+            UIManager.put(element + "." + attribute, Color.BLUE);
+        }
+        public void paintUIAttributeCyan(String element, String attribute) {
+            UIManager.put(element + "." + attribute, Color.CYAN);
+        }
+        public void paintUIAttributeDarkGray(String element, String attribute) {
+            UIManager.put(element + "." + attribute, Color.DARK_GRAY);
+        }
+        public void paintUIAttributeGray(String element, String attribute) {
+            UIManager.put(element + "." + attribute, Color.GRAY);
+        }
+        public void paintUIAttributeGreen(String element, String attribute) {
+            UIManager.put(element + "." + attribute, Color.GREEN);
+        }
+        public void paintUIAttributeLightGray(String element, String attribute) {
+            UIManager.put(element + "." + attribute, Color.LIGHT_GRAY);
+        }
+        public void paintUIAttributeMagenta(String element, String attribute) {
+            UIManager.put(element + "." + attribute, Color.MAGENTA);
+        }
+        public void paintUIAttributePink(String element, String attribute) {
+            UIManager.put(element + "." + attribute, Color.PINK);
+        }
+        public void paintUIAttributeRed(String element, String attribute) {
+            UIManager.put(element + "." + attribute, Color.RED);
+        }
+        public void paintUIAttributeWhite(String element, String attribute) {
+            UIManager.put(element + "." + attribute, Color.WHITE);
+        }
+        public void paintUIAttributeYellow(String element, String attribute) {
+            UIManager.put(element + "." + attribute, Color.YELLOW);
+        }
+        public void updateLookAndFeel(JFrame jFrame) {
+            SwingUtilities.updateComponentTreeUI(jFrame);
+        }
+    }
+
+    public static final NativeJTextArea nativeJTextArea = new NativeJTextArea();
+    public static class NativeJTextArea {
+        public JTextArea create(int rows, int columns) {
+            return new JTextArea(rows, columns);
+        }
+    }
+
+    public static final NativeJFileChooser nativeJFileChooser = new NativeJFileChooser();
+    public static class NativeJFileChooser {
+        public JFileChooser create(String currentDirectoryPath) {
+            return new JFileChooser(currentDirectoryPath);
+        }
+        public int getApproveOption() {
+            return JFileChooser.APPROVE_OPTION;
+        }
+    }
+
+    public static final NativeJScrollPane nativeJScrollPane = new NativeJScrollPane();
+    public static class NativeJScrollPane {
+        public JScrollPane create(JTextArea view, int vsbPolicy, int hsbPolicy) {
+            return new JScrollPane(view, vsbPolicy, hsbPolicy);
+        }
+        public int getHorizontalScrollbarAlwaysValue() {
+            return JScrollPane.HORIZONTAL_SCROLLBAR_ALWAYS;
+        }
+        public int getVerticalScrollbarAlwaysValue() {
+            return JScrollPane.VERTICAL_SCROLLBAR_ALWAYS;
+        }
+    }
+
+    public static final NativeJFrame nativeJFrame = new NativeJFrame();
+    public static class NativeJFrame {
+        public JFrame create() {
+            return new JFrame();
+        }
+        public int getExitOnClose() {
+            return JFrame.EXIT_ON_CLOSE;
+        }
+    }
+
+    public static final NativeJMenuBar nativeJMenuBar = new NativeJMenuBar();
+    public static class NativeJMenuBar {
+        public JMenuBar create() {
+            return new JMenuBar();
+        }
+    }
+
+    public static final NativeJMenu nativeJMenu = new NativeJMenu();
+    public static class NativeJMenu {
+        public JMenu create(String s) {
+            return new JMenu(s);
+        }
+    }
+
+    public static final NativeJOptionPane nativeJOptionPane = new NativeJOptionPane();
+    public static class NativeJOptionPane {
+        public int showConfirmDialog(Object message, String title, int optionType) {
+            return JOptionPane.showConfirmDialog(null, message, title, optionType);
+        }
+        public void showMessageDialog(Object message, String title, int messageType) {
+            JOptionPane.showMessageDialog(null, message, title, messageType);
+        }
+        public int getYesNoOptionValue() {
+            return JOptionPane.YES_NO_OPTION;
+        }
+        public int getYesOptionValue() {
+            return JOptionPane.YES_OPTION;
+        }
+        public int getErrorMessageValue() {
+            return JOptionPane.ERROR_MESSAGE;
+        }
+        public int getPlainMessageValue() {
+            return JOptionPane.PLAIN_MESSAGE;
+        }
+    }
+
+    public static final NativeActionCreator nativeActionCreator = new NativeActionCreator();
+    public static class NativeActionCreator {
+        public NativeAction createWithAction(String name, ObjectValue action) {
+            return new NativeAction(name, action);
+        }
+        public NativeAction create(String name) {
+            return new NativeAction(name);
+        }
+    }
+
+    public static class NativeAction extends AbstractAction {
+        private static final long serialVersionUID = 1L;
+        private ObjectValue action;
+
+        public NativeAction(String name) {
+            super(name);
+        }
+
+        public NativeAction(String name, ObjectValue action) {
+            super(name);
+            this.action = action;
+        }
+
+        public void setAction(ObjectValue action) {
+            this.action = action;
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            if (action != null) {
+                action.invoke("apply", new LinkedList<Value>()).executeIfThunk();
+            }
+        }
+    }
+
+    public static final NativeKeyListenerCreator nativeKeyListenerCreator = new NativeKeyListenerCreator();
+    public static class NativeKeyListenerCreator {
+        public NativeKeyListener create(ObjectValue keyAction) {
+            return new NativeKeyListener(keyAction);
+        }
+    }
+
+    public static class NativeKeyListener extends KeyAdapter {
+        private final ObjectValue keyAction;
+
+        public NativeKeyListener(ObjectValue keyAction) {
+            this.keyAction = keyAction;
+        }
+
+        @Override
+        public void keyPressed(KeyEvent e) {
+            if (keyAction != null) {
+                keyAction.invoke("apply", new LinkedList<Value>()).executeIfThunk();
+            }
+        }
+    }
+}


### PR DESCRIPTION
See [`README`](https://github.com/wyvernlang/wyvern/compare/text-editor?expand=1#diff-8fd621e94683c9d3a92b6faec83f06d3) for how to use the text-editor application and extend it with plugins.

Currently, the application isn't annotated with effects because 1) it relies on Wyvern code that is currently unannotated (e.g., [`fileSystem`](https://github.com/wyvernlang/wyvern/blob/master/stdlib/platform/java/fileSystem.wyv)) and 2) more discussion is needed about how to associate effects with Java objects.

Also, there are two places (namely, in [`textEditor.wyv`](https://github.com/wyvernlang/wyvern/compare/text-editor?expand=1#diff-ea5e9c364f9de65028a3c7431c40d487) and [`NativeUIManager.wyt`](https://github.com/wyvernlang/wyvern/compare/text-editor?expand=1#diff-7bbe3a73c6723b515a6bae406e5c13c4)) where the `Dyn` type is used, which are known issues.
