### PR TITLE
Splits the FFI effect into two: FFIWrite and FFIRead

### DIFF
--- a/examples/AlexTalkDemos/10-EditorCaps/logger.wyv
+++ b/examples/AlexTalkDemos/10-EditorCaps/logger.wyv
@@ -1,6 +1,6 @@
 module def logger(out : Stdout):Logger
 
-effect log = {system.FFI}
+effect log = {system.FFIWrite}
 
 def log(msg : String) : Unit
   out.print("LOG: " + msg + "\n")

--- a/examples/AlexTalkDemos/11-EditorEffects/polymorphicEffects/file.wyv
+++ b/examples/AlexTalkDemos/11-EditorEffects/polymorphicEffects/file.wyv
@@ -1,5 +1,5 @@
 module def file(java:Java) : polymorphicEffects.Resource
 
-effect wr = {system.FFI}
+effect wr = {system.FFIWrite}
 def write() : {wr} Unit
     unit

--- a/examples/AlexTalkDemos/11-EditorEffects/polymorphicEffects/network.wyv
+++ b/examples/AlexTalkDemos/11-EditorEffects/polymorphicEffects/network.wyv
@@ -1,5 +1,5 @@
 module def network(java:Java) : polymorphicEffects.Resource
 
-effect wr = {system.FFI}
+effect wr = {system.FFIWrite}
 def write() : {wr} Unit
     unit

--- a/examples/effects/fileEffects.wyv
+++ b/examples/effects/fileEffects.wyv
@@ -1,6 +1,6 @@
 module fileEffects
 
-effect Read = {system.FFI}
-effect Write = {system.FFI}
-effect Append = {system.FFI}
-effect Delete = {system.FFI}
+effect Read = {system.FFIRead}
+effect Write = {system.FFIWrite}
+effect Append = {system.FFIWrite}
+effect Delete = {system.FFIWrite}

--- a/stdlib/platform/java/annotatedFileSystem.wyv
+++ b/stdlib/platform/java/annotatedFileSystem.wyv
@@ -15,7 +15,7 @@ import fileSystem.ByteArray
 import wyvern.option
 type Option = option.Option
 
-effect createNewFile = {system.FFI}
+effect createNewFile = {system.FFIWrite}
 effect Read = {fileEffects.Read}
 effect Write = {fileEffects.Write}
 effect Append = {fileEffects.Append}
@@ -25,15 +25,15 @@ def fileFor(path: String) : {} File = new
     effect Read = {fileEffects.Read}
     effect Write = {fileEffects.Write}
     effect Append = {fileEffects.Append}
-    effect openForRead = {system.FFI}
-    effect openForWrite = {system.FFI}
-    effect openForAppend = {system.FFI}
-    effect openForRandomAccess = {system.FFI}
+    effect openForRead = {system.FFIRead}
+    effect openForWrite = {system.FFIWrite}
+    effect openForAppend = {system.FFIWrite}
+    effect openForRandomAccess = {system.FFIWrite}
 
     def makeReader() : {} BoundedReader
         val br = file.openBRForRead(this.f)
         new (self) =>
-            effect Read = {system.FFI}
+            effect Read = {system.FFIRead}
             def read() : {self.Read} Int
                 file.readCharFromFile(br)
             def readLine() : {self.Read}  Option[String]
@@ -50,7 +50,7 @@ def fileFor(path: String) : {} File = new
     def makeWriter() : {} Writer
         val bw = file.openBWForWrite(this.f)
         new (self) =>
-            effect Write = {system.FFI}
+            effect Write = {system.FFIWrite}
             def write(s : String) : {self.Write} Unit
                 file.writeString(bw, s)        //again temporary limits on write format
             def close() : {} Unit
@@ -65,7 +65,7 @@ def fileFor(path: String) : {} File = new
     def makeAppender() : {} Writer
         val bw = file.openBWForAppend(this.f)
         new (self) =>
-            effect Write = {system.FFI}
+            effect Write = {system.FFIWrite}
             def write(s : String) : {self.Write} Unit
                 file.writeString(bw, s)        //again temporary limits on write format
             def close() : {} Unit
@@ -103,8 +103,8 @@ def fileFor(path: String) : {} File = new
     def makeRandomAccessFile(mode : String) : {} RandomAccessFile
         val rf = file.makeRandomAccessFile(this.f, mode)
         new (self) =>
-            effect Read  = {system.FFI}
-            effect Write = {system.FFI}
+            effect Read  = {system.FFIRead}
+            effect Write = {system.FFIWrite}
             def close() : {} Unit
                 file.closeRandomAccessFile(rf)
             def getPosition() : {} Int

--- a/stdlib/platform/java/arrayListMaker.wyv
+++ b/stdlib/platform/java/arrayListMaker.wyv
@@ -3,10 +3,10 @@ import java:wyvern.stdlib.support.ArrayListWrapper.arraylist
 import fileSystem.File
 import ArrayList
 
-effect makelist = {system.FFI}
+effect makelist = {system.FFIWrite}
 def make() : {makelist} ArrayList = new
-    effect read = {system.FFI}
-    effect write = {system.FFI}
+    effect read = {system.FFIRead}
+    effect write = {system.FFIWrite}
     val l = arraylist.makeArrayList()
     def isEmpty() : {} Boolean
         this.l.isEmpty()

--- a/stdlib/platform/java/fileSystem/fileEffects.wyv
+++ b/stdlib/platform/java/fileSystem/fileEffects.wyv
@@ -1,6 +1,6 @@
 module fileEffects : {}
-effect Read = {system.FFI}
-effect Write = {system.FFI}
-effect Append = {system.FFI} //probably difficult to distinguish
+effect Read = {system.FFIRead}
+effect Write = {system.FFIWrite}
+effect Append = {system.FFIWrite} //probably difficult to distinguish
 //Close effect? should it be needed to indicate flushing streams?
 //Create effect, for when writing/reading files whether they already exist or not

--- a/stdlib/platform/java/fileSystemClient.wyv
+++ b/stdlib/platform/java/fileSystemClient.wyv
@@ -1,4 +1,4 @@
-module def fileSystemClient(fileSys : fileSystem.FileSystem) : {system.FFI}
+module def fileSystemClient(fileSys : fileSystem.FileSystem) : {}
 import annotatedFileSystem
 
 def make() : Unit

--- a/stdlib/platform/java/stdout.wyv
+++ b/stdlib/platform/java/stdout.wyv
@@ -11,8 +11,10 @@ type Printable = Unit
 either add a '\n' to the string you want to print, to use println()
 instead, or call flush() right after print(). */
 
-effect print = {system.FFI}
-effect flush = {system.FFI}
+/* Note: both effects are "write" because we are writing to the console. */
+effect print = {system.FFIWrite}
+effect flush = {system.FFIWrite}
+
 def print(text:String): {print} Unit
 	stdio.print(text)
 

--- a/tools/src/wyvern/stdlib/Globals.java
+++ b/tools/src/wyvern/stdlib/Globals.java
@@ -195,7 +195,7 @@ public final class Globals {
         intDeclTypes.add(new DefDeclType(">=", Util.booleanType(), Arrays.asList(new FormalArg("other", Util.intType()))));
         intDeclTypes.add(new DefDeclType("!=", Util.booleanType(), Arrays.asList(new FormalArg("other", Util.intType()))));
 
-        
+
         List<DeclType> floatDeclTypes = new LinkedList<DeclType>();
         floatDeclTypes.add(new DefDeclType("+", Util.floatType(), Arrays.asList(new FormalArg("other", Util.floatType()))));
         floatDeclTypes.add(new DefDeclType("-", Util.floatType(), Arrays.asList(new FormalArg("other", Util.floatType()))));
@@ -209,8 +209,8 @@ public final class Globals {
         floatDeclTypes.add(new DefDeclType("<=", Util.booleanType(), Arrays.asList(new FormalArg("other", Util.floatType()))));
         floatDeclTypes.add(new DefDeclType(">=", Util.booleanType(), Arrays.asList(new FormalArg("other", Util.floatType()))));
         floatDeclTypes.add(new DefDeclType("!=", Util.booleanType(), Arrays.asList(new FormalArg("other", Util.floatType()))));
-        
-        
+
+
         ValueType intType = new StructuralType("intSelf", intDeclTypes);
         ValueType boolType = new StructuralType("boolean", boolDeclTypes);
         ValueType floatType = new StructuralType("float", floatDeclTypes);
@@ -227,7 +227,7 @@ public final class Globals {
         stringDeclTypes.add(new DefDeclType("<=", Util.booleanType(), Arrays.asList(new FormalArg("other", Util.stringType()))));
         stringDeclTypes.add(new DefDeclType(">=", Util.booleanType(), Arrays.asList(new FormalArg("other", Util.stringType()))));
         stringDeclTypes.add(new DefDeclType("!=", Util.booleanType(), Arrays.asList(new FormalArg("other", Util.stringType()))));
-        
+
         stringDeclTypes.add(new DefDeclType("equals", Util.booleanType(), Arrays.asList(new FormalArg("other", Util.stringType()))));
         stringDeclTypes.add(new DefDeclType("length", Util.intType(), new LinkedList<FormalArg>()));
         stringDeclTypes.add(new DefDeclType("charAt", Util.charType(), Arrays.asList(new FormalArg("index", Util.intType()))));
@@ -245,7 +245,7 @@ public final class Globals {
         charDeclTypes.add(new DefDeclType("!=", Util.booleanType(), Arrays.asList(new FormalArg("other", Util.charType()))));
         charDeclTypes.add(new DefDeclType("<=", Util.booleanType(), Arrays.asList(new FormalArg("other", Util.charType()))));
         charDeclTypes.add(new DefDeclType(">=", Util.booleanType(), Arrays.asList(new FormalArg("other", Util.charType()))));
-        
+
         ValueType charType = new StructuralType("charSelf", charDeclTypes);
         declTypes.add(new ConcreteTypeMember("Character", charType));
 
@@ -272,8 +272,9 @@ public final class Globals {
         declTypes.add(new ConcreteTypeMember("Python", pythonTagType));
         declTypes.add(new AbstractTypeMember("Context"));
         declTypes.add(new ValDeclType("unit", Util.unitType()));
-        //declTypes.add(new EffectDeclType("ffiEffect", null, null));
         declTypes.add(new EffectDeclType("FFI", null, null));
+        declTypes.add(new EffectDeclType("FFIRead", null, null));
+        declTypes.add(new EffectDeclType("FFIWrite", null, null));
         ValueType systemType = new StructuralType(new BindingSite("this"), declTypes);
         return systemType;
     }

--- a/tools/src/wyvern/stdlib/Globals.java
+++ b/tools/src/wyvern/stdlib/Globals.java
@@ -272,7 +272,6 @@ public final class Globals {
         declTypes.add(new ConcreteTypeMember("Python", pythonTagType));
         declTypes.add(new AbstractTypeMember("Context"));
         declTypes.add(new ValDeclType("unit", Util.unitType()));
-        declTypes.add(new EffectDeclType("FFI", null, null));
         declTypes.add(new EffectDeclType("FFIRead", null, null));
         declTypes.add(new EffectDeclType("FFIWrite", null, null));
         ValueType systemType = new StructuralType(new BindingSite("this"), declTypes);

--- a/tools/src/wyvern/target/corewyvernIL/type/ValueType.java
+++ b/tools/src/wyvern/target/corewyvernIL/type/ValueType.java
@@ -62,6 +62,7 @@ public abstract class ValueType extends Type implements IASTNode {
      */
     public abstract void doPrettyPrint(Appendable dest, String indent, TypeContext ctx) throws IOException;
 
+    @Override
     public final void doPrettyPrint(Appendable dest, String indent) throws IOException {
         doPrettyPrint(dest, indent, null);
     }
@@ -121,7 +122,7 @@ public abstract class ValueType extends Type implements IASTNode {
         }
         return st.findMatchingDecl(name, exclusionFilter, ctx);
     }
-    
+
     /** Find the declaration type with the specified name, or return null if it is not present */
     public DeclType findDecl(String declName, TypeContext ctx) {
         StructuralType st = getStructuralType(ctx);
@@ -136,7 +137,7 @@ public abstract class ValueType extends Type implements IASTNode {
     public List<DeclType> findDecls(String declName, TypeContext ctx) {
         StructuralType st = getStructuralType(ctx);
         if (st == null) {
-            return (List<DeclType>) Collections.EMPTY_LIST;
+            return Collections.EMPTY_LIST;
         }
         return st.findDecls(declName, ctx);
     }
@@ -148,7 +149,7 @@ public abstract class ValueType extends Type implements IASTNode {
     public abstract ValueType doAvoid(String varName, TypeContext ctx, int depth);
 
     public boolean equalsInContext(ValueType otherType, TypeContext ctx, FailureReason reason) {
-        return this.isSubtypeOf(otherType, ctx, reason) && otherType.isSubtypeOf(this, ctx, reason);
+        return isSubtypeOf(otherType, ctx, reason) && otherType.isSubtypeOf(this, ctx, reason);
     }
 
     /**
@@ -191,7 +192,7 @@ public abstract class ValueType extends Type implements IASTNode {
      * Some types that are effect-annotated and not effect-unannotated:
      *
      *   type T
-     *     def foo() : {system.FFI} Unit
+     *     def foo() : {system.FFIRead} Unit
      *
      *   type U
      *     effect E [ = ... ]
@@ -209,7 +210,7 @@ public abstract class ValueType extends Type implements IASTNode {
      * Some types that are neither effect-annotated nor effect-unannotated
      *
      *   type T
-     *     def foo() : {system.FFI} Unit
+     *     def foo() : {system.FFIRead} Unit
      *     def bar() : Unit
      *
      *   type U

--- a/tools/src/wyvern/tools/tests/EffectAnnotationTests.java
+++ b/tools/src/wyvern/tools/tests/EffectAnnotationTests.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
 import wyvern.stdlib.Globals;
 import wyvern.target.corewyvernIL.type.ValueType;
 import wyvern.tools.imports.extensions.WyvernResolver;
@@ -30,13 +31,13 @@ public class EffectAnnotationTests {
 
     private static void assertAnnotationStatus(
             boolean annotated, boolean unannotated, String... declarations
-    ) throws ParseException {
+            ) throws ParseException {
         Assert.assertEquals(annotated,
                 buildStructuralType(declarations).isEffectAnnotated(Globals.getStandardTypeContext())
-        );
+                );
         Assert.assertEquals(unannotated,
                 buildStructuralType(declarations).isEffectUnannotated(Globals.getStandardTypeContext())
-        );
+                );
     }
 
     @BeforeClass public static void setupResolver() {
@@ -48,56 +49,56 @@ public class EffectAnnotationTests {
     public void testBasic1() throws ParseException {
         assertAnnotationStatus(true, false,
                 "def foo() : {} Unit"
-        );
+                );
     }
 
     @Test
     public void testBasic2() throws ParseException {
         assertAnnotationStatus(true, false,
-                "def foo() : {system.FFI} Unit"
-        );
+                "def foo() : {system.FFIRead} Unit"
+                );
     }
 
     @Test
     public void testBasic3() throws ParseException {
         assertAnnotationStatus(true, false,
                 "effect E"
-        );
+                );
     }
 
     @Test
     public void testBasic4() throws ParseException {
         assertAnnotationStatus(true, false,
                 "effect E = {}"
-        );
+                );
     }
 
     @Test
     public void testBasic5() throws ParseException {
         assertAnnotationStatus(true, false,
-                "effect E = {system.FFI}"
-        );
+                "effect E = {system.FFIRead}"
+                );
     }
 
     @Test
     public void testBasic6() throws ParseException {
         assertAnnotationStatus(false, true,
                 "def bar() : Unit"
-        );
+                );
     }
 
     @Test
     public void testBasic7() throws ParseException {
         assertAnnotationStatus(true, true,
                 "val x : Int"
-        );
+                );
     }
 
     @Test
     public void testBasic8() throws ParseException {
         assertAnnotationStatus(true, true,
                 "val x : Int"
-        );
+                );
     }
 
     @Test
@@ -107,15 +108,15 @@ public class EffectAnnotationTests {
                 "val y : String",
                 "type U",
                 "type V = Float"
-        );
+                );
     }
 
     @Test
     public void testBasic10() throws ParseException {
         assertAnnotationStatus(false, false,
-                "def foo() : {system.FFI} Unit",
+                "def foo() : {system.FFIRead} Unit",
                 "def bar() : Unit"
-        );
+                );
     }
 
     @Test
@@ -123,7 +124,7 @@ public class EffectAnnotationTests {
         assertAnnotationStatus(false, false,
                 "def bar() : Unit",
                 "effect E"
-        );
+                );
     }
 
     @Test
@@ -131,22 +132,22 @@ public class EffectAnnotationTests {
         assertAnnotationStatus(false, false,
                 "def bar() : Unit",
                 "effect E = {}"
-        );
+                );
     }
 
     @Test
     public void testBasic13() throws ParseException {
         assertAnnotationStatus(false, false,
                 "def bar() : Unit",
-                "effect E = {system.FFI}"
-        );
+                "effect E = {system.FFIRead}"
+                );
     }
 
     @Test
     public void testBasic14() throws ParseException {
         assertAnnotationStatus(true, false,
                 "type U\n      effect E"
-        );
+                );
 
     }
 
@@ -154,34 +155,34 @@ public class EffectAnnotationTests {
     public void testBasic15() throws ParseException {
         assertAnnotationStatus(true, true,
                 "type U = list.List[Int]"
-        );
+                );
     }
 
     @Test
     public void testBasic16() throws ParseException {
         assertAnnotationStatus(true, true,
                 "type U = MyType"
-        );
+                );
     }
 
     @Test
     public void testBasic17() throws ParseException {
         assertAnnotationStatus(true, true,
                 "type U = MyType[Int]"
-        );
+                );
     }
 
     @Test
     public void testBasic18() throws ParseException {
         assertAnnotationStatus(true, false,
                 "type U = MyType[Int, {}]"
-        );
+                );
     }
 
     @Test
     public void testBasic19() throws ParseException {
         assertAnnotationStatus(true, false,
-                "type U = MyType[Int, {system.FFI}]"
-        );
+                "type U = MyType[Int, {system.FFIRead}]"
+                );
     }
 }

--- a/tools/src/wyvern/tools/tests/EffectSystemTests.java
+++ b/tools/src/wyvern/tools/tests/EffectSystemTests.java
@@ -112,7 +112,7 @@ public class EffectSystemTests {
 
     @Test
     public void testFileIO() throws ParseException {
-        /* Globally available effects (system.FFI) are used in effect definitions in module (only). */
+        /* Globally available effects (system.FFIRead and system.FFIWrite) are used in effect definitions in module (only). */
         TestUtil.doTestScriptModularly(PATH, "effects.testFileIO", Util.intType(), new IntegerLiteral(3));
     }
 
@@ -143,8 +143,7 @@ public class EffectSystemTests {
 
     @Test
     public void testLogger() throws ParseException {
-        /* A method has an effect annotation involving a globally available effect (system.FFI)
-         * in module but not in type. */
+        /* A method has an effect annotation in module but not in type. */
         expectedException.expect(ToolError.class);
         expectedException.expectMessage(StringContains.containsString("Method body's type resource type"));
         expectedException.expectMessage(StringContains.containsString("is not a subtype of declared type "
@@ -155,10 +154,10 @@ public class EffectSystemTests {
 
     @Test
     public void testLogger1() throws ParseException {
-        /* Globally available effect (system.FFI) is attempted to be used to annotate a method directly
+        /* A globally available effect (system.FFIWrite) is used to annotate a method directly
          * without having exposed the effect definition in the type. */
         expectedException.expect(ToolError.class);
-        expectedException.expectMessage(StringContains.containsString("Effect annotation {system.FFI} "
+        expectedException.expectMessage(StringContains.containsString("Effect annotation {system.FFIWrite} "
                 + "on method updateLog is not a subtype of effects that method produces, which are [fio.writeF];  at location file "
                 + Paths.get(PATH, "effects", "logger1.wyv").toAbsolutePath().toString()));
         TestUtil.doTestScriptModularly(PATH, "effects.testLogger1", Util.intType(), new IntegerLiteral(5));
@@ -183,7 +182,7 @@ public class EffectSystemTests {
 
     @Test
     public void testLogger4() throws ParseException {
-        /* Globally available effect (system.FFI) is used to annotate a method directly
+        /* Globally available effect (system.FFIWrite) is used to annotate a method directly
          * without defining any local effects. */
         TestUtil.doTestScriptModularly(PATH, "effects.testLogger4", Util.intType(), new IntegerLiteral(5));
     }

--- a/tools/src/wyvern/tools/tests/editor/editor.wyv
+++ b/tools/src/wyvern/tools/tests/editor/editor.wyv
@@ -24,9 +24,9 @@ def createFile(path : String) : {filesys.createNewFile, filelist.write} File
     filelist.add(file)
     file
 
-val filelist2 : ArrayList[{system.FFI}, {system.FFI}] = new
-    effect read = {system.FFI}
-    effect write = {system.FFI}
+val filelist2 : ArrayList[{system.FFIRead}, {system.FFIWrite}] = new
+    effect read = {system.FFIRead}
+    effect write = {system.FFIWrite}
     def isEmpty() : {} Boolean
         filelist.isEmpty()
     def add(f : File) : {filelist.write} Boolean

--- a/tools/src/wyvern/tools/tests/effectSeparation/file5.wyv
+++ b/tools/src/wyvern/tools/tests/effectSeparation/file5.wyv
@@ -1,4 +1,4 @@
 // Pure module, but with a non-empty effect annotation
-module file5 : {system.FFI}
+module file5 : {system.FFIRead}
 def x() : Unit
     unit

--- a/tools/src/wyvern/tools/tests/effects/FileIO4.wyt
+++ b/tools/src/wyvern/tools/tests/effects/FileIO4.wyt
@@ -1,5 +1,5 @@
 resource type FileIO4
     effect readF
-    effect writeF = {system.FFI}
+    effect writeF = {system.FFIWrite}
     def read(): {this.readF} Int
     def write(x: Int): {this.writeF} Int

--- a/tools/src/wyvern/tools/tests/effects/FileIO6.wyt
+++ b/tools/src/wyvern/tools/tests/effects/FileIO6.wyt
@@ -1,3 +1,3 @@
 resource type FileIO6
-    def read(): {system.FFI} Int
-    def write(x: Int): {system.FFI} Int
+    def read(): {system.FFIRead} Int
+    def write(x: Int): {system.FFIWrite} Int

--- a/tools/src/wyvern/tools/tests/effects/Logger1.wyt
+++ b/tools/src/wyvern/tools/tests/effects/Logger1.wyt
@@ -1,2 +1,2 @@
 resource type Logger1
-    def updateLog(x: Int): {system.FFI} Int
+    def updateLog(x: Int): {system.FFIWrite} Int

--- a/tools/src/wyvern/tools/tests/effects/fileIO.wyv
+++ b/tools/src/wyvern/tools/tests/effects/fileIO.wyv
@@ -1,7 +1,7 @@
 module def fileIO(java: Java): effects.FileIO
 import java:wyvern.tools.tests.Illustrations.nativeFileIO
-effect readF = {system.FFI}
-effect writeF = {system.FFI}
+effect readF = {system.FFIRead}
+effect writeF = {system.FFIWrite}
 
 def read(): {readF} Int
     nativeFileIO.read()

--- a/tools/src/wyvern/tools/tests/effects/fileIO3.wyv
+++ b/tools/src/wyvern/tools/tests/effects/fileIO3.wyv
@@ -1,7 +1,7 @@
 module def fileIO(java: Java): effects.FileIO3
 import java:wyvern.tools.tests.Illustrations.nativeFileIO
-effect read = {system.FFI}
-effect write = {system.FFI}
+effect read = {system.FFIRead}
+effect write = {system.FFIWrite}
 
 def read(): {read} Int
     nativeFileIO.read()

--- a/tools/src/wyvern/tools/tests/effects/fileIO4.wyv
+++ b/tools/src/wyvern/tools/tests/effects/fileIO4.wyv
@@ -1,7 +1,7 @@
 module def fileIO(java: Java): effects.FileIO4
 import java:wyvern.tools.tests.Illustrations.nativeFileIO
-effect readF = {system.FFI}
-effect writeF = {system.FFI}
+effect readF = {system.FFIRead}
+effect writeF = {system.FFIWrite}
 
 def read(): {readF} Int
     nativeFileIO.read()

--- a/tools/src/wyvern/tools/tests/effects/fileIOEffects.wyv
+++ b/tools/src/wyvern/tools/tests/effects/fileIOEffects.wyv
@@ -1,3 +1,3 @@
 module fileIOEffects
-effect readF = {system.FFI}
-effect writeF = {system.FFI}
+effect readF = {system.FFIRead}
+effect writeF = {system.FFIWrite}

--- a/tools/src/wyvern/tools/tests/effects/logger1.wyv
+++ b/tools/src/wyvern/tools/tests/effects/logger1.wyv
@@ -1,3 +1,3 @@
 module def logger1(fio: effects.FileIO): effects.Logger1
-def updateLog(x: Int): {system.FFI} Int
+def updateLog(x: Int): {system.FFIWrite} Int
     fio.write(x)

--- a/tools/src/wyvern/tools/tests/effects/logger4.wyv
+++ b/tools/src/wyvern/tools/tests/effects/logger4.wyv
@@ -1,3 +1,3 @@
 module def logger4(fio: effects.FileIO4): effects.Logger1
-def updateLog(x: Int): {system.FFI} Int
+def updateLog(x: Int): {system.FFIWrite} Int
     fio.write(x)

--- a/tools/src/wyvern/tools/tests/effects/logger5.wyv
+++ b/tools/src/wyvern/tools/tests/effects/logger5.wyv
@@ -1,3 +1,3 @@
 module def logger5(fio: effects.FileIO6): effects.Logger1
-def updateLog(x: Int): {system.FFI} Int
+def updateLog(x: Int): {system.FFIWrite} Int
     fio.write(x)

--- a/tools/src/wyvern/tools/tests/effects/nested.wyv
+++ b/tools/src/wyvern/tools/tests/effects/nested.wyv
@@ -1,5 +1,5 @@
 module nested
 
 val x = new
-  effect e = {system.FFI}
+  effect e = {system.FFIRead}
   def id(x: Int): {this.e} Int = x

--- a/tools/src/wyvern/tools/tests/effects/network10Effects.wyv
+++ b/tools/src/wyvern/tools/tests/effects/network10Effects.wyv
@@ -1,3 +1,3 @@
 module network10Effects
 effect sendFx = {}
-effect receiveFx = {system.FFI}
+effect receiveFx = {system.FFIRead}

--- a/tools/src/wyvern/tools/tests/higherOrderEffects/AcceptedFile1.wyt
+++ b/tools/src/wyvern/tools/tests/higherOrderEffects/AcceptedFile1.wyt
@@ -1,4 +1,4 @@
 resource type AcceptedFile1
     effect write
-    def go() : {} ((Unit -> {system.FFI} Unit) -> {} Unit)
+    def go() : {} ((Unit -> {system.FFIWrite} Unit) -> {} Unit)
 

--- a/tools/src/wyvern/tools/tests/higherOrderEffects/AcceptedFile2.wyt
+++ b/tools/src/wyvern/tools/tests/higherOrderEffects/AcceptedFile2.wyt
@@ -1,3 +1,3 @@
 resource type AcceptedFile2
     effect write
-    def go() : {} (Unit -> {system.FFI} Unit)
+    def go() : {} (Unit -> {system.FFIWrite} Unit)

--- a/tools/src/wyvern/tools/tests/higherOrderEffects/RejectedFile2.wyt
+++ b/tools/src/wyvern/tools/tests/higherOrderEffects/RejectedFile2.wyt
@@ -1,3 +1,3 @@
 resource type RejectedFile2
     effect write
-    def go() : {} (Unit -> {system.FFI} Unit)
+    def go() : {} (Unit -> {system.FFIWrite} Unit)

--- a/tools/src/wyvern/tools/tests/higherOrderEffects/acceptedClient1.wyv
+++ b/tools/src/wyvern/tools/tests/higherOrderEffects/acceptedClient1.wyv
@@ -3,9 +3,9 @@ import lifted higherOrderEffects.acceptedLib1
 
 val ubFile : AcceptedFile1[{}] = new
     effect write = {}
-    def go() : {} ((Unit -> {system.FFI} Unit) -> {} Unit)
-        y : (Unit -> {system.FFI} Unit) => unit
+    def go() : {} ((Unit -> {system.FFIWrite} Unit) -> {} Unit)
+        y : (Unit -> {system.FFIWrite} Unit) => unit
 
-val ublib = acceptedLib1[{system.FFI}](ubFile)
+val ublib = acceptedLib1[{system.FFIWrite}](ubFile)
 
 "abc"

--- a/tools/src/wyvern/tools/tests/higherOrderEffects/acceptedClient1a.wyv
+++ b/tools/src/wyvern/tools/tests/higherOrderEffects/acceptedClient1a.wyv
@@ -3,8 +3,8 @@ import lifted higherOrderEffects.acceptedLib1
 
 val ubFile : AcceptedFile1[{}] = new
     effect write = {}
-    def go() : {} ((Unit -> {system.FFI} Unit) -> {} Unit)
-        y : (Unit -> {system.FFI} Unit) => unit
+    def go() : {} ((Unit -> {system.FFIWrite} Unit) -> {} Unit)
+        y : (Unit -> {system.FFIWrite} Unit) => unit
 
 val ublib = acceptedLib1[{}](ubFile)
 

--- a/tools/src/wyvern/tools/tests/higherOrderEffects/acceptedClient2.wyv
+++ b/tools/src/wyvern/tools/tests/higherOrderEffects/acceptedClient2.wyv
@@ -1,8 +1,8 @@
 import higherOrderEffects.AcceptedFile2
 import lifted higherOrderEffects.acceptedLib2
 
-val file : AcceptedFile2[{system.FFI}] = new
-    effect write = {system.FFI}
+val file : AcceptedFile2[{system.FFIWrite}] = new
+    effect write = {system.FFIWrite}
     def go() : {} (Unit -> {this.write} Unit)
         () => unit
 

--- a/tools/src/wyvern/tools/tests/higherOrderEffects/rejectedClient1.wyv
+++ b/tools/src/wyvern/tools/tests/higherOrderEffects/rejectedClient1.wyv
@@ -12,7 +12,7 @@ val ubFile : RejectedFile1[{}] = new
     def go() : {} ((Unit -> {} Unit) -> {} Unit)
         y : (Unit -> {} Unit) => unit
 
-// This causes an error since FFI is not in the upper bound
-val ublib = rejectedLib1[{system.FFI}](ubFile)
+// This causes an error since FFIWrite is not in the upper bound
+val ublib = rejectedLib1[{system.FFIWrite}](ubFile)
 
 "abc"

--- a/tools/src/wyvern/tools/tests/higherOrderEffects/rejectedClient2.wyv
+++ b/tools/src/wyvern/tools/tests/higherOrderEffects/rejectedClient2.wyv
@@ -5,8 +5,8 @@
 import higherOrderEffects.RejectedFile2
 import lifted higherOrderEffects.rejectedLib2
 
-val file : RejectedFile2[{system.FFI}] = new
-    effect write = {system.FFI}
+val file : RejectedFile2[{system.FFIWrite}] = new
+    effect write = {system.FFIWrite}
     def go() : {} (Unit -> {this.write} Unit)
         () => unit
 

--- a/tools/src/wyvern/tools/tests/higherOrderEffects/rejectedClient3.wyv
+++ b/tools/src/wyvern/tools/tests/higherOrderEffects/rejectedClient3.wyv
@@ -2,8 +2,8 @@
 import higherOrderEffects.RejectedFile3
 import lifted higherOrderEffects.rejectedLib3
 
-val file : RejectedFile3[{system.FFI}] = new
-    effect write = {system.FFI}
+val file : RejectedFile3[{system.FFIWrite}] = new
+    effect write = {system.FFIWrite}
     def go(f : (Unit -> {this.write} Unit) -> {} Unit) : {} Unit
         unit
 

--- a/tools/src/wyvern/tools/tests/higherOrderEffects/rejectedClient4.wyv
+++ b/tools/src/wyvern/tools/tests/higherOrderEffects/rejectedClient4.wyv
@@ -2,8 +2,8 @@
 import higherOrderEffects.RejectedFile4
 import lifted higherOrderEffects.rejectedLib4
 
-val file : RejectedFile4[{system.FFI}] = new
-    effect write = {system.FFI}
+val file : RejectedFile4[{system.FFIWrite}] = new
+    effect write = {system.FFIWrite}
     def go(f : (Unit -> {this.write} Unit) -> {} Unit) : {} Unit
         unit
 

--- a/tools/src/wyvern/tools/tests/higherOrderEffects/ubClient.wyv
+++ b/tools/src/wyvern/tools/tests/higherOrderEffects/ubClient.wyv
@@ -6,8 +6,8 @@ val ubFile : UbFile[{}] = new
     def writeToFile(f : Unit -> {} Unit) : {} Unit
         unit
 
-// This causes an error since FFI is not in the upper bound
-val ublib = ubLib[{system.FFI}](ubFile)
+// This causes an error since FFIWrite is not in the upper bound
+val ublib = ubLib[{system.FFIWrite}](ubFile)
 
 "abc"
 

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/basicManual.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/basicManual.wyv
@@ -1,8 +1,8 @@
 type Generic
   effect E
 
-val u : Generic[{system.FFI}] = new
-  effect E = {system.FFI}
+val u : Generic[{system.FFIRead, system.FFIWrite}] = new
+  effect E = {system.FFIRead, system.FFIWrite}
 
 def id(g : Generic, x : String) : {g.E} String
   x

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/basicNaming.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/basicNaming.wyv
@@ -1,8 +1,8 @@
 type Generic
   effect E
 
-val u : Generic[{system.FFI}] = new
-  effect E = {system.FFI}
+val u : Generic[{system.FFIRead, system.FFIWrite}] = new
+  effect E = {system.FFIRead, system.FFIWrite}
 
 // Calling the effect parameter "E" is okay too (even with {u.E} defined)
 def id[effect E, T](x : T) : {E} T

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/basicParameters1.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/basicParameters1.wyv
@@ -1,8 +1,8 @@
 type Generic
   effect E
 
-val u : Generic[{system.FFI}] = new
-  effect E = {system.FFI}
+val u : Generic[{system.FFIRead, system.FFIWrite}] = new
+  effect E = {system.FFIRead, system.FFIWrite}
 
 def id[T, effect F](x : T) : {F} T
   x

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/basicParameters2.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/basicParameters2.wyv
@@ -1,8 +1,8 @@
 type Generic
   effect E
 
-val u : Generic[{system.FFI}] = new
-  effect E = {system.FFI}
+val u : Generic[{system.FFIRead, system.FFIWrite}] = new
+  effect E = {system.FFIRead, system.FFIWrite}
 
 def id[effect F, T](x : T) : {F} T
   x

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/basicStructuralEquality.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/basicStructuralEquality.wyv
@@ -1,14 +1,14 @@
 type Generic
   effect E
 
-val u : Generic[{system.FFI}] = new
-  effect E = {system.FFI}
+val u : Generic[{system.FFIRead, system.FFIWrite}] = new
+  effect E = {system.FFIRead, system.FFIWrite}
 
 def id(g : Generic, x : String) : {g.E} String
   x
 
 // Structural equality of effects
-def run() : {system.FFI} String
+def run() : {system.FFIRead, system.FFIWrite} String
   id(u, "abc")
 
 run()

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/basicTypeInference.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/basicTypeInference.wyv
@@ -1,8 +1,8 @@
 type Generic
   effect E
 
-val u : Generic[{system.FFI}] = new
-  effect E = {system.FFI}
+val u : Generic[{system.FFIRead, system.FFIWrite}] = new
+  effect E = {system.FFIRead, system.FFIWrite}
 
 def id[effect F, T](x : T) : {F} T
   x

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/client.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/client.wyv
@@ -1,8 +1,8 @@
 import lifted polymorphicEffects.unannotatedPlugin
 import polymorphicEffects.Logger
 
-val logger : Logger[{system.FFI}] = new
-    effect log = {system.FFI}
+val logger : Logger[{system.FFIWrite}] = new
+    effect log = {system.FFIWrite}
     def append(contents : String) : {this.log} Unit
         unit
 

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/combination1.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/combination1.wyv
@@ -1,10 +1,10 @@
 type Generic
   effect E
 
-val q : Generic[{system.FFI}] = new
-  effect E = {system.FFI}
+val q : Generic[{system.FFIRead, system.FFIWrite}] = new
+  effect E = {system.FFIRead, system.FFIWrite}
 
-val r : Generic[{system.FFI}] = new
+val r : Generic[{system.FFIRead, system.FFIWrite}] = new
   effect E = {}
 
 val s : Generic[{}] = new

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/combination2.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/combination2.wyv
@@ -1,10 +1,10 @@
 type Generic
   effect E
 
-val q : Generic[{system.FFI}] = new
-  effect E = {system.FFI}
+val q : Generic[{system.FFIRead, system.FFIWrite}] = new
+  effect E = {system.FFIRead, system.FFIWrite}
 
-val r : Generic[{system.FFI}] = new
+val r : Generic[{system.FFIRead, system.FFIWrite}] = new
   effect E = {}
 
 val s : Generic[{}] = new

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/file.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/file.wyv
@@ -1,5 +1,5 @@
 module def file(java:Java) : polymorphicEffects.Resource
 
-effect wr = {system.FFI}
+effect wr = {system.FFIWrite}
 def write() : {wr} Unit
     unit

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/function.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/function.wyv
@@ -2,7 +2,7 @@ type Generic
   effect E
 
 val u : Generic = new
-  effect E = {system.FFI}
+  effect E = {system.FFIRead, system.FFIWrite}
 
 type Function
   effect E

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/import2Client.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/import2Client.wyv
@@ -2,8 +2,8 @@
 import polymorphicEffects.File
 import lifted polymorphicEffects.lib
 
-val file : File[{system.FFI}] = new
-    effect write = {system.FFI}
+val file : File[{system.FFIWrite}] = new
+    effect write = {system.FFIWrite}
     def writeToFile() : {this.write} Unit
         unit
 

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/import3Rejected.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/import3Rejected.wyv
@@ -6,13 +6,13 @@ import lifted polymorphicEffects.import3Lib
 type UnitFnWithoutEffect
     def app() : {} Unit
 
-val g : Go [{system.FFI}] = new
+val g : Go [{system.FFIWrite}] = new
     // x should be a function without effect
     def go (x : Unit -> {} Unit) : {} Unit
         x()
 
-val file1 : File[{system.FFI}] = new
-    effect write = {system.FFI}
+val file1 : File[{system.FFIWrite}] = new
+    effect write = {system.FFIWrite}
     def writeToFile() : {this.write} Unit
         unit
 

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/import3empty.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/import3empty.wyv
@@ -4,7 +4,7 @@ import polymorphicEffects.Go
 import polymorphicEffects.UnitFnWithoutEffect
 import lifted polymorphicEffects.import3Lib
 
-val g : Go [{system.FFI}] = new
+val g : Go [{system.FFIWrite}] = new
     def go (x : Unit -> {} Unit) : {} Unit
         x()
 

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/network.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/network.wyv
@@ -1,5 +1,5 @@
 module def network(java:Java) : polymorphicEffects.Resource
 
-effect wr = {system.FFI}
+effect wr = {system.FFIWrite}
 def write() : {wr} Unit
     unit

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/parametricModuleFunctor1.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/parametricModuleFunctor1.wyv
@@ -1,7 +1,7 @@
 import polymorphicEffects.parametricLib
 
 val u = new
-  effect E = {system.FFI}
+  effect E = {system.FFIRead, system.FFIWrite}
 
 val lib = parametricLib[Int, {u.E}]()
 

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/parametricModuleFunctor2.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/parametricModuleFunctor2.wyv
@@ -1,7 +1,7 @@
 import polymorphicEffects.parametricLib
 
 val u = new
-  effect E = {system.FFI}
+  effect E = {system.FFIRead, system.FFIWrite}
 
 val lib = parametricLib[String, {u.E}]()
 

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/rejectedAbstractTypeRefinement.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/rejectedAbstractTypeRefinement.wyv
@@ -8,7 +8,7 @@ val myLogger : Logger = new
     s
 
 val u = new
-  effect E = {system.FFI}
+  effect E = {system.FFIRead, system.FFIWrite}
 
 // Cannot refine abstract type
 type S = myLogger.T[{u.E}]

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/rejectedCombination1.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/rejectedCombination1.wyv
@@ -1,10 +1,10 @@
 type Generic
   effect E
 
-val q : Generic[{system.FFI}] = new
-  effect E = {system.FFI}
+val q : Generic[{system.FFIRead, system.FFIWrite}] = new
+  effect E = {system.FFIRead, system.FFIWrite}
 
-val r : Generic[{system.FFI}] = new
+val r : Generic[{system.FFIRead, system.FFIWrite}] = new
   effect E = {}
 
 val s : Generic[{}] = new
@@ -16,7 +16,7 @@ val t : Generic = new
 def id[effect E, T](x : T) : {E} T
   x
 
-// {q.E} = {system.FFI}, which is not a subset of {s.E} = {}
+// {q.E} = {system.FFIRead, system.FFIWrite}, which is not a subset of {s.E} = {}
 def run() : {s.E} String
   id[{q.E}]("abc")
 

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/rejectedCombination2.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/rejectedCombination2.wyv
@@ -1,10 +1,10 @@
 type Generic
   effect E
 
-val q : Generic[{system.FFI}] = new
-  effect E = {system.FFI}
+val q : Generic[{system.FFIRead, system.FFIWrite}] = new
+  effect E = {system.FFIRead, system.FFIWrite}
 
-val r : Generic[{system.FFI}] = new
+val r : Generic[{system.FFIRead, system.FFIWrite}] = new
   effect E = {}
 
 val s : Generic[{}] = new
@@ -16,8 +16,8 @@ val t : Generic = new
 def id[effect E, T](x : T) : {E} T
   x
 
-// {r.E} is actually {}, but is declared to be {system.FFI}, so the effect
-// checker will reject passing in {r.E} here because {system.FFI} is not a
+// {r.E} is actually {}, but is declared to be {system.FFIRead, system.FFIWrite}, so the effect
+// checker will reject passing in {r.E} here because {system.FFIRead, system.FFIWrite} is not a
 // subset of {s.E} = {}
 def run() : {s.E} String
   id[{r.E}]("abc")

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/rejectedCombination3.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/rejectedCombination3.wyv
@@ -1,10 +1,10 @@
 type Generic
   effect E
 
-val q : Generic[{system.FFI}] = new
-  effect E = {system.FFI}
+val q : Generic[{system.FFIRead, system.FFIWrite}] = new
+  effect E = {system.FFIRead, system.FFIWrite}
 
-val r : Generic[{system.FFI}] = new
+val r : Generic[{system.FFIRead, system.FFIWrite}] = new
   effect E = {}
 
 val s : Generic[{}] = new

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/rejectedEditor1.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/rejectedEditor1.wyv
@@ -8,10 +8,10 @@ type Resource
   effect theEffect
 
 val file : Resource = new
-  effect theEffect = {system.FFI}
+  effect theEffect = {system.FFIWrite}
 
 val network : Resource = new
-  effect theEffect = {system.FFI}
+  effect theEffect = {system.FFIWrite}
 
 // Different implementations of Logger
 

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/rejectedEditor2.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/rejectedEditor2.wyv
@@ -8,10 +8,10 @@ type Resource
   effect theEffect
 
 val file : Resource = new
-  effect theEffect = {system.FFI}
+  effect theEffect = {system.FFIWrite}
 
 val network : Resource = new
-  effect theEffect = {system.FFI}
+  effect theEffect = {system.FFIWrite}
 
 // Different implementations of Logger
 

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/rejectedFunctionSubtype.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/rejectedFunctionSubtype.wyv
@@ -2,7 +2,7 @@ type Generic
   effect E
 
 val u : Generic = new
-  effect E = {system.FFI}
+  effect E = {system.FFIRead, system.FFIWrite}
 
 type Function
   effect E

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/rejectedHiddenEffects.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/rejectedHiddenEffects.wyv
@@ -5,7 +5,7 @@ def id[effect F, T](x : T) : {F} T
 // Related to the "avoidance problem"
 def run() : {} String
   val v = new
-    effect hiddenEffect = {system.FFI}
+    effect hiddenEffect = {system.FFIRead, system.FFIWrite}
   id[{v.hiddenEffect}, String]("abc")
 
 run()

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/rejectedNotInferrable.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/rejectedNotInferrable.wyv
@@ -1,8 +1,8 @@
 type Generic
   effect E
 
-val u : Generic[{system.FFI}] = new
-  effect E = {system.FFI}
+val u : Generic[{system.FFIRead, system.FFIWrite}] = new
+  effect E = {system.FFIRead, system.FFIWrite}
 
 def id[T, effect F](x : T) : {F} T
   x

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/rejectedParametricModuleFunctor1.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/rejectedParametricModuleFunctor1.wyv
@@ -1,7 +1,7 @@
 import polymorphicEffects.parametricLib
 
 val u = new
-  effect E = {system.FFI}
+  effect E = {system.FFIRead, system.FFIWrite}
 
 val lib = parametricLib[Int, {u.E}]()
 

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/rejectedParametricModuleFunctor2.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/rejectedParametricModuleFunctor2.wyv
@@ -1,7 +1,7 @@
 import polymorphicEffects.parametricLib
 
 val u = new
-  effect E = {system.FFI}
+  effect E = {system.FFIRead, system.FFIWrite}
 
 val v = new
   effect E = {}
@@ -9,7 +9,7 @@ val v = new
 val lib = parametricLib[String, {u.E}]()
 
 def run() : {v.E} String
-  // Rejected because {u.E} = {system.FFI} is not a subset of {v.E} = {}
+  // Rejected because {u.E} = {system.FFIRead, system.FFIWrite} is not a subset of {v.E} = {}
   lib.id("abc")
 
 run()

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/rejectedSubset.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/rejectedSubset.wyv
@@ -1,13 +1,13 @@
 type Generic
   effect E
 
-val u : Generic[{system.FFI}] = new
-  effect E = {system.FFI}
+val u : Generic[{system.FFIRead, system.FFIWrite}] = new
+  effect E = {system.FFIRead, system.FFIWrite}
 
 def id(g : Generic, x : String) : {g.E} String
   x
 
-// {u.E} = {system.FFI} is not a subset of {}
+// {u.E} = {system.FFIRead, system.FFIWrite} is not a subset of {}
 def run() : {} String
   id(u, "abc")
 

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/rejectedSubtype.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/rejectedSubtype.wyv
@@ -1,8 +1,8 @@
 type Generic
   effect E
 
-// {system.FFI} is NOT a subtype of {}, so NOT OK
+// {system.FFIRead, system.FFIWrite} is NOT a subtype of {}, so NOT OK
 val u : Generic[{}] = new
-  effect E = {system.FFI}
+  effect E = {system.FFIRead, system.FFIWrite}
 
 "abc"

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/subtype1.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/subtype1.wyv
@@ -1,8 +1,8 @@
 type Generic
   effect E
 
-// {system.FFI} is a subset of {system.FFI}, so OK
-val u : Generic[{system.FFI}] = new
-  effect E = {system.FFI}
+// {system.FFIRead, system.FFIWrite} is a subset of {system.FFIRead, system.FFIWrite}, so OK
+val u : Generic[{system.FFIRead, system.FFIWrite}] = new
+  effect E = {system.FFIRead, system.FFIWrite}
 
 "abc"

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/subtype2.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/subtype2.wyv
@@ -1,8 +1,8 @@
 type Generic
   effect E
 
-// {} is a subtype of {system.FFI}, so OK
-val u : Generic[{system.FFI}] = new
+// {} is a subtype of {system.FFIRead, system.FFIWrite}, so OK
+val u : Generic[{system.FFIRead, system.FFIWrite}] = new
   effect E = {}
 
 val s : Generic[{}] = new

--- a/tools/src/wyvern/tools/tests/polymorphicEffects/subtype4.wyv
+++ b/tools/src/wyvern/tools/tests/polymorphicEffects/subtype4.wyv
@@ -6,6 +6,6 @@ val u : Generic = new
   effect E = {}
 
 val v : Generic = new
-  effect E = {system.FFI}
+  effect E = {system.FFIRead, system.FFIWrite}
 
 "abc"


### PR DESCRIPTION
Currently, there is only one globally available, foreign-function-interface (FFI) effect, `system.FFI`. This effect is associated with the `system` object representing the FFI and can be used anywhere in the program without having to be imported.

This PR replaces `system.FFI` with two effects `system.FFIWrite` and `system.FFIRead`. The former effect is for methods that make modifications to FFI objects (e.g., a file write), and the latter is for methods that retrieve information from FFI objects (e.g., a file read).

In places where the original `system.FFI` effect was used to indicate that a method can have _any_ effect, now a set containing both new effects (namely, `{system.FFIRead, system.FFIWrite}`) should be used. Notably, due to finer granularity, this change allows to indicate that a method can have any effect that _only retrieves_ information from FFI object or _only modifies_ FFI objects.
