### PR TITLE
Fix EQARROW not resetting flagTok

### DIFF
--- a/tools/src/wyvern/tools/lexing/WyvernLexer.x
+++ b/tools/src/wyvern/tools/lexing/WyvernLexer.x
@@ -266,7 +266,7 @@ import static wyvern.tools.parsing.coreparser.WyvernParserConstants.*;
         RESULT = token(EQARROW,lexeme);
         if (flagTok == null) {
             flagTok = RESULT;
-					  flagTokSet = true;
+			flagTokSet = true;
         }
     :};
  	terminal Token tarrow_t ::= /-\>/  {: RESULT = token(TARROW,lexeme); :};
@@ -528,7 +528,7 @@ import static wyvern.tools.parsing.coreparser.WyvernParserConstants.*;
 	                      		RESULT = n;
 	                        :}
 	                      | lineElementSequence:list anyLineElement:n {:
-                                if (flagTok != null && flagTok.kind == EQARROW && list.size() > 0 && ((Token) list.get(list.size()-1)).kind != EQARROW && ((Token) list.get(list.size()-1)).kind != WHITESPACE) {
+                                if (flagTok != null && flagTok.kind == EQARROW && !isEQARROWlast) {
                                     flagTok = null;
                                 }
                                 list.addAll(n); RESULT = list;
@@ -557,7 +557,7 @@ import static wyvern.tools.parsing.coreparser.WyvernParserConstants.*;
 
 	ilineElementSequence ::= iindent_t:n {: RESULT = LexerUtils.makeList(n); flagTok = null; lastIndent = n; :}
 	                      | ilineElementSequence:list anyLineElement:n {:
-                                if (flagTok != null && flagTok.kind == EQARROW && list.size() > 0 && ((Token) list.get(list.size()-1)).kind != EQARROW && ((Token) list.get(list.size()-1)).kind != WHITESPACE) {
+                                if (flagTok != null && flagTok.kind == EQARROW && !isEQARROWlast) {
                                     flagTok = null;
                                 }
                                 list.addAll(n); RESULT = list;

--- a/tools/src/wyvern/tools/lexing/WyvernLexer.x
+++ b/tools/src/wyvern/tools/lexing/WyvernLexer.x
@@ -519,6 +519,7 @@ import static wyvern.tools.parsing.coreparser.WyvernParserConstants.*;
     
 	lineElementSequence ::= indent_t:n {: RESULT = LexerUtils.makeList(n); flagTok = null; lastIndent = n; :}
 	                      | nonWSLineElement:n {:
+	                            adjustEQARROW(n);
 	                            lastIndent = null;
 	                            // handles lines that start without any indent
 	                            if (inDSL)
@@ -528,6 +529,7 @@ import static wyvern.tools.parsing.coreparser.WyvernParserConstants.*;
 	                      		RESULT = n;
 	                        :}
 	                      | lineElementSequence:list anyLineElement:n {:
+	                            	adjustEQARROW(n);
                                 if (flagTok != null && flagTok.kind == EQARROW && !isEQARROWlast) {
                                     flagTok = null;
                                 }
@@ -557,6 +559,7 @@ import static wyvern.tools.parsing.coreparser.WyvernParserConstants.*;
 
 	ilineElementSequence ::= iindent_t:n {: RESULT = LexerUtils.makeList(n); flagTok = null; lastIndent = n; :}
 	                      | ilineElementSequence:list anyLineElement:n {:
+	                            	adjustEQARROW(n);
                                 if (flagTok != null && flagTok.kind == EQARROW && !isEQARROWlast) {
                                     flagTok = null;
                                 }

--- a/tools/src/wyvern/tools/tests/LexingTests.java
+++ b/tools/src/wyvern/tools/tests/LexingTests.java
@@ -3,10 +3,13 @@ package wyvern.tools.tests;
 import static wyvern.tools.parsing.coreparser.WyvernParserConstants.CHARACTER_LITERAL;
 import static wyvern.tools.parsing.coreparser.WyvernParserConstants.DASH;
 import static wyvern.tools.parsing.coreparser.WyvernParserConstants.DATATYPE;
+import static wyvern.tools.parsing.coreparser.WyvernParserConstants.DECIMAL_LITERAL;
 import static wyvern.tools.parsing.coreparser.WyvernParserConstants.DEDENT;
 import static wyvern.tools.parsing.coreparser.WyvernParserConstants.DEF;
 import static wyvern.tools.parsing.coreparser.WyvernParserConstants.DIVIDE;
 import static wyvern.tools.parsing.coreparser.WyvernParserConstants.DSLLINE;
+import static wyvern.tools.parsing.coreparser.WyvernParserConstants.EQARROW;
+import static wyvern.tools.parsing.coreparser.WyvernParserConstants.GT;
 import static wyvern.tools.parsing.coreparser.WyvernParserConstants.IDENTIFIER;
 import static wyvern.tools.parsing.coreparser.WyvernParserConstants.INDENT;
 import static wyvern.tools.parsing.coreparser.WyvernParserConstants.LPAREN;
@@ -328,6 +331,19 @@ public class LexingTests {
         int[] expected = new int[] {
                 INDENT, WHITESPACE, IDENTIFIER, WHITESPACE, NEWLINE,
                 WHITESPACE, IDENTIFIER, NEWLINE, DEDENT,
+        };
+        checkLex(input, expected);
+    }
+
+    @Test
+    public void testEqarrowBeforeDSLIndent() throws IOException, CopperParserException {
+        String input =
+                "if ((x => x)(2) > 1)\n"
+                    + "  foo\n";
+        int[] expected = new int[] {
+                IDENTIFIER, WHITESPACE, LPAREN, LPAREN, IDENTIFIER, WHITESPACE, EQARROW, WHITESPACE, IDENTIFIER,
+                RPAREN, LPAREN, DECIMAL_LITERAL, RPAREN, WHITESPACE, GT, WHITESPACE, DECIMAL_LITERAL, RPAREN, WHITESPACE, NEWLINE,
+                WHITESPACE, DSLLINE,
         };
         checkLex(input, expected);
     }


### PR DESCRIPTION
Currently the lexer does not always reset flagTok from EQARROW to null when "=>" is not the last non-whitespace token. The following code causes the indentation on line 2 to be lexed as a regular indent instead of a dsl indent.
```
if (((x: Int) => x + 1)(2) > 3)
    stdout.print("yes")
  else
    stdout.print("no")
```

The problem is due to [the eqarrow check](https://github.com/wyvernlang/wyvern/blob/92025a284f10eac3e33085a4387e1d60731e1297/tools/src/wyvern/tools/lexing/WyvernLexer.x#L531) requiring the last token in list to not be whitespace, which is true for line 1 in the code snippet above.

The proposed fix uses the isEQARROWlast flag instead for this check. To make this work, adjustEQARROW() is called on every line element to make sure the flag is updated.

~TODO: I will update this PR with test cases.~ (done)