### PR TITLE
Added examples of implicit type conversion in both example folder and OIRTests. Fixed minor problems regarding option type check.

### DIFF
--- a/examples/optionType.wyv
+++ b/examples/optionType.wyv
@@ -1,13 +1,22 @@
 require stdout
 
+// helper function to print out strings with String? type
 def print(str: String?): Unit
   if (str.isDefined)
         stdout.print(str.get() + "\n")
     else
-        stdout.print("None\n")
+        stdout.print("NONE\n")
 
-var str: String? = option.Some[String]("Life is Good!")
-print(str)
+var str1: String? = option.Some[String]("Hello, World!")
+print(str1)
 
-str = NONE
-print(str)
+// implicit type conversion from String to String?
+str1 = "Life is Good!"
+print(str1)
+
+// str1 is assignable to NONE since NONE is the supertype of option types
+str1 = NONE
+print(str1)
+
+val str2: String? = "Life is Wonderful!"
+print(str2)

--- a/examples/optionType.wyv
+++ b/examples/optionType.wyv
@@ -10,7 +10,7 @@ def print(str: String?): Unit
 var str1: String? = option.Some[String]("Hello, World!")
 print(str1)
 
-// implicit type conversion from String to String?
+// implicit type conversion from String to String? for assignment
 str1 = "Life is Good!"
 print(str1)
 
@@ -18,5 +18,6 @@ print(str1)
 str1 = NONE
 print(str1)
 
+// implicit type conversion from String to String? for val declaration
 val str2: String? = "Life is Wonderful!"
 print(str2)

--- a/tools/src/wyvern/tools/tests/OIRTests.java
+++ b/tools/src/wyvern/tools/tests/OIRTests.java
@@ -779,6 +779,28 @@ public class OIRTests {
     }
 
     @Test
+    public void testOptionTypeSugar() throws ParseException {
+        String input =
+          "require stdout\n"
+          + "var str1: String? = option.Some[String](\"Hello, World!\")\n"
+          + "stdout.print(str1.get())\n"
+          + "stdout.println()\n"
+          + "\n"
+          + "str1 = \"Life is Good!\"\n"
+          + "stdout.print(str1.get())\n"
+          + "stdout.println()\n"
+          + "\n"
+          + "str1 = NONE\n"
+          + "\n"
+          + "val str2: String? = \"Life is Wonderful!\"\n"
+          + "stdout.print(str2.get())\n"
+          + "stdout.println()\n"
+          + "\n"
+          + "0";
+      testPyFromInput(input, "Hello, World!\nLife is Good!\nLife is Wonderful!\n0");
+    }
+
+    @Test
     @Category(CurrentlyBroken.class)
     public void testRationalOperators() throws ParseException {
         String input =

--- a/tools/src/wyvern/tools/typedAST/core/declarations/ValDeclaration.java
+++ b/tools/src/wyvern/tools/typedAST/core/declarations/ValDeclaration.java
@@ -86,7 +86,10 @@ public class ValDeclaration extends Declaration implements CoreAST {
           rhsExpressionType, 
           this.getLocation());
 
-        rhsExpression = rhsOptionExpression == null ? rhsExpression : rhsOptionExpression; 
+        // keep the original rhs expression or
+        // obtain the option type expression
+        // if passed type check.
+        rhsExpression = (rhsOptionExpression == null ? rhsExpression : rhsOptionExpression); 
 
         tlc.addLet(new BindingSite(getName()),
                 lhsExpressionExpectedType,

--- a/tools/src/wyvern/tools/typedAST/core/expressions/Assignment.java
+++ b/tools/src/wyvern/tools/typedAST/core/expressions/Assignment.java
@@ -98,14 +98,15 @@ public class Assignment extends AbstractExpressionAST implements CoreAST {
 
         // case when lhs has expected type of RefinementType and rhs has actually that is not of Refinement Type
         if (lhsExpressionExpectedType instanceof RefinementType) {
+
           // cast the type memeber to refinement type
           RefinementType lhsExpectedType = (RefinementType) lhsExpressionExpectedType;
 
           // extract base type of the LHS expected type, "option.Option", getBase returns ValueType
           ValueType lhsBaseType = lhsExpectedType.getBase();
 
-          // check whether the base type of the refinement type is of option.Option type
-          if (lhsBaseType.equals(new NominalType("option", "Option"))) {
+          if (lhsBaseType.equals(new NominalType("option", "Option")) 
+           || lhsBaseType.equals(new NominalType("MOD$wyvern.option", "Option"))) {
 
             // obtain the generic argument list from the lhs Refinement Type
             List<GenericArgument> genList = lhsExpectedType.getGenericArguments();
@@ -132,7 +133,7 @@ public class Assignment extends AbstractExpressionAST implements CoreAST {
 
                 // convert rhs actual assignment type T to lhs type option.Option[T]
                 // Modify the expr to assign (RHS), to emulate the option expression based on the base type (RHS Expression Type)
-                rhsExpression = new MethodCall((IExpr) new wyvern.target.corewyvernIL.expression.Variable("option", location),
+                return new MethodCall((IExpr) new wyvern.target.corewyvernIL.expression.Variable(((NominalType) lhsBaseType).getPath().toString(), location),
                                               "Some",
                                               iExprList,
                                               null);
@@ -166,8 +167,11 @@ public class Assignment extends AbstractExpressionAST implements CoreAST {
           rhsExpression, 
           rhsExpressionType, 
           this.getLocation());
-          
-        rhsExpression = rhsOptionExpression == null ? rhsExpression : rhsOptionExpression; 
+
+        // keep the original rhs expression or
+        // obtain the option type expression
+        // if passed type check.
+        rhsExpression = (rhsOptionExpression == null ? rhsExpression : rhsOptionExpression); 
 
         // Assigning to a top-level var.
         if (lhsExpression instanceof MethodCall) {


### PR DESCRIPTION
Added examples of implicit type conversion in both example folder and OIRTests. Fixed minor problems regarding option type check. Modified generateOptionTypeExpr function to include MOD.option as a path variable.