### PR TITLE
Support explicit option type conversion from T? to T using "!" operator

### DIFF
--- a/examples/optionType.wyv
+++ b/examples/optionType.wyv
@@ -7,10 +7,13 @@ def print(str: String?): Unit
     else
         stdout.print("NONE\n")
 
+// Section for implicit option type conversion
+
+// implicit type conversion from String to String? for var declaration
 var str1: String? = "Hello, World!"
 print(str1)
 
-// implicit type conversion from String to String? for assignment
+// implicit type conversion from String to String? for assignment statement
 str1 = "Life is Good!"
 print(str1)
 
@@ -21,3 +24,19 @@ print(str1)
 // implicit type conversion from String to String? for val declaration
 val str2: String? = "Life is Wonderful!"
 print(str2)
+
+
+// Section for explicit option type conversion
+// Note that at this point, str2 is of type String?
+
+// explicit type conversion from String? (str2) to String (str3) for var declaration
+var str3: String = str2!
+stdout.print(str3 + "\n")
+
+// explicit type conversion from String? (str2) to String (str3) for assignment statement
+str3 = str2!
+stdout.print(str3 + "\n")
+
+// explicit type conversion from String? (str2) to String (str4) for val declaration
+val str4:String = str2!
+stdout.print(str4 + "\n")

--- a/tools/src/wyvern/tools/parsing/coreparser/ASTBuilder.java
+++ b/tools/src/wyvern/tools/parsing/coreparser/ASTBuilder.java
@@ -41,6 +41,7 @@ interface ASTBuilder<AST, Type> {
     Object formalArg(String name, Type type);
     AST fn(List args, AST body, FileLocation loc);
     AST var(String name, FileLocation loc);
+    AST var(String name, FileLocation loc, boolean isExplicitTypeConversion);
     AST stringLit(String value, FileLocation loc);
     AST characterLit(char value, FileLocation loc);
     AST integerLit(BigInteger value, FileLocation loc);

--- a/tools/src/wyvern/tools/parsing/coreparser/WyvernASTBuilder.java
+++ b/tools/src/wyvern/tools/parsing/coreparser/WyvernASTBuilder.java
@@ -344,7 +344,12 @@ public class WyvernASTBuilder implements ASTBuilder<TypedAST, Type> {
 
     @Override
     public TypedAST var(String name, FileLocation loc) {
-        return new Variable(name, loc);
+        return new Variable(name, loc, false);
+    }
+
+    @Override
+    public TypedAST var(String name, FileLocation loc, boolean isExplicitTypeConversion) {
+        return new Variable(name, loc, isExplicitTypeConversion);
     }
 
     @Override

--- a/tools/src/wyvern/tools/parsing/coreparser/WyvernParser.jj
+++ b/tools/src/wyvern/tools/parsing/coreparser/WyvernParser.jj
@@ -982,11 +982,11 @@ void Extension(LinkedList<String> names, LinkedList<AST> args) :
 }
 
 AST PrimaryPrefix(ExpFlags flags) :
-{ AST exp; Token t; boolean recur = false; }
+{ AST exp; Token t; Token t2 = null; boolean recur = false; }
 {
   exp = Literal() { return exp; }
 |
-  (<RECUR>)? { recur = true; } t = <IDENTIFIER> { return build.var(t.image, loc(t));  }
+  (<RECUR>)? { recur = true; } t = <IDENTIFIER> [ t2 = <BOOLEANNOT> ] { return build.var(t.image, loc(t), t2 != null);  }
 |
   <LPAREN> exp = Expression(flags) <RPAREN> { return exp; }
 |

--- a/tools/src/wyvern/tools/typedAST/core/expressions/Variable.java
+++ b/tools/src/wyvern/tools/typedAST/core/expressions/Variable.java
@@ -20,10 +20,16 @@ public class Variable extends AbstractExpressionAST implements CoreAST, Assignab
 
     private String name;
     private FileLocation location = FileLocation.UNKNOWN;
+    private boolean isExplicitTypeConversion;
 
     public Variable(String name, FileLocation location) {
+        this(name, location, false);
+    }
+
+    public Variable(String name, FileLocation location, boolean isExplicitTypeConversion) {
         this.name = name;
         this.location = location;
+        this.isExplicitTypeConversion = isExplicitTypeConversion;
     }
 
     public String getName() {
@@ -49,7 +55,21 @@ public class Variable extends AbstractExpressionAST implements CoreAST, Assignab
             GenContext ctx,
             ValueType expectedType,
             List<TypedModuleSpec> dependencies) {
-        return ctx.lookupExp(getName(), location);
+        IExpr match = ctx.lookupExp(getName(), location);
+        
+        if (match instanceof wyvern.target.corewyvernIL.expression.Variable
+          && isExplicitTypeConversion) {
+
+          // set explicit conversion flag to true for the matched variable expression
+          ((wyvern.target.corewyvernIL.expression.Variable) match).setExplicitConversionFlag();
+
+        } else if (match instanceof wyvern.target.corewyvernIL.expression.MethodCall
+          && isExplicitTypeConversion) {
+
+          // set explicit conversion flag to true for the matched method calls
+          ((wyvern.target.corewyvernIL.expression.MethodCall) match).setExplicitConversionFlag();
+        }
+        return match;
     }
 
     @Override

--- a/tools/src/wyvern/tools/typedAST/core/expressions/Variable.java
+++ b/tools/src/wyvern/tools/typedAST/core/expressions/Variable.java
@@ -63,11 +63,6 @@ public class Variable extends AbstractExpressionAST implements CoreAST, Assignab
           // set explicit conversion flag to true for the matched variable expression
           ((wyvern.target.corewyvernIL.expression.Variable) match).setExplicitConversionFlag();
 
-        } else if (match instanceof wyvern.target.corewyvernIL.expression.MethodCall
-          && isExplicitTypeConversion) {
-
-          // set explicit conversion flag to true for the matched method calls
-          ((wyvern.target.corewyvernIL.expression.MethodCall) match).setExplicitConversionFlag();
         }
         return match;
     }


### PR DESCRIPTION
Support explicit option type conversion from T? to T using "!" operator for val declaration, var declaration and assignment statement. Modified example program optionType.wyv in the example folder.

Supported the follow expression:
```scala
val str: String? = "Hello, Wyvern!"
val str1: String = str! // converted str from String? type to String type in val declaration
var str2: String = str! //  converted str from String? type to String type in var declaration
str2 = str! // converted str from String? type to String type in assignment statement
```