### PR TITLE
adding member function type declarations--now 1+1 can be typed

### DIFF
--- a/selfhost/binding.wyv
+++ b/selfhost/binding.wyv
@@ -33,6 +33,9 @@ def bindDeclTypes(e:raw.Exp, context:bound.Context):List[types.DeclType] = match
     v:raw.ValType =>
         val b = types.Binding(v.name, context.counter)
         llist.Singleton[types.DeclType](types.ValType(b,stringToType(v.typ, context)))
+    d:raw.DefDecl =>
+        val b = types.Binding(d.name, context.counter)
+        llist.Singleton[types.DeclType](types.DefType(b, stringToType(d.argTyp, context), stringToType(d.retTyp,context)))
     default       => error.report("unexpected construct", error.unknownLocation)
     
 def bindHelper(e:raw.Exp, context:bound.Context):bound.Exp = match e:
@@ -41,7 +44,8 @@ def bindHelper(e:raw.Exp, context:bound.Context):bound.Exp = match e:
     l:raw.Lambda =>
         val b = types.Binding(l.name, context.counter)
         bound.Lambda(b, bindHelper(l.body, context.extend(b)))
-    c:raw.Call   => bound.Call(bindHelper(c.receiver, context), c.name, bindHelper(c.arg, context))
+    c:raw.Call   => 
+        bound.Call(bindHelper(c.receiver, context), c.name, bindHelper(c.arg, context))
     v:raw.Val    =>
         val b = types.Binding(v.name, context.counter)
         bound.Val(b, bindHelper(v.exp, context))

--- a/selfhost/lambda.wyv
+++ b/selfhost/lambda.wyv
@@ -30,7 +30,7 @@ val parser = wyvernParser.makeParser(lexer)
 // simple test case
 //parser.feed("def f(x) = x\nval y = ( x => x)\n( x => x) (x => x)\n(x => x) (003+3202 * (65537 % 2) / -2 + -(2 - 3))\ntype foo:\n    val x:Int\n    val y:Int\n5\n")
 //parser.feed("(x => -x / -(3*5))")
-parser.feed("type Int:\n    val a:Int\nval x = 5\nval y = x\nval z = y\nz")
+parser.feed("type Int:\n    def +(i:Int):Int\n    def -(i:Int):Int\nval x = 5\nval y = x\nval z = y\nz+0-x+3+5")
 /* debugging code, currently commented out
 */
 js.log("Raw Results:\n")

--- a/selfhost/raw.wyv
+++ b/selfhost/raw.wyv
@@ -12,6 +12,7 @@ datatype Exp
     Val(name:String, exp:Exp)
     ValType(name:String, typ:String)
     TypeDecl(name:String, decls:String)
+    DefDecl(name:String, arg:String, argTyp:String, retTyp:String)
     Seq(exps:List[Exp])
     Integer(str:String)    
 

--- a/selfhost/typecheck.wyv
+++ b/selfhost/typecheck.wyv
@@ -7,14 +7,34 @@ import wyvern.collections.llist
 type List = llist.LinkedList
 type DeclType = types.DeclType
 
-def unfoldType(x:types.NominalType, gamma:List[DeclType]):DeclType
-    val pred = ((b:DeclType) =>
-        val z = match b:
-            t:types.TypeType => types.equalBinding(x.L, t.name)
-            default => false
-        z
-    )
-    llist.find[DeclType](gamma, pred).get()
+/*
+def searchGamma[T](gamma:List[DeclType], pred:DeclType->Boolean):T
+    val opt = llist.find[DeclType](gamma, pred)
+    match opt:
+        s:option.Some => 
+            val ret:DeclType = opt.get()
+            match ret:
+                t:T => t
+                default => error.report("search in gamma failed",error.unknownLocation)
+        n:option.None => error.report("search in gamma failed",error.unknownLocation)
+*/
+
+def unfoldType(x:types.Type, gamma:List[DeclType]):types.UnfoldedType
+    match x:
+        u:types.UnitType => types.UnfoldedType(llist.Nil[DeclType]())
+        x:types.NominalType => 
+            val pred = ((b:DeclType) =>
+                val z = match b:
+                    t:types.TypeType => types.equalBinding(x.L, t.name)
+                    default => false
+                z
+            )
+            val ret = llist.find[DeclType](gamma, pred).get()
+            match ret:
+                t:types.TypeType => t.typ
+                default => error.report("unfolding error",error.unknownLocation)
+        u:types.UnfoldedType => u
+
 
 def typecheck(e:bound.Exp):types.Type
     getType(e,llist.Nil[DeclType]())
@@ -32,9 +52,33 @@ def getType(e:bound.Exp, gamma:List[DeclType]):types.Type = match e:
             va:types.ValType => va.typ
             default => error.report("var not bound",error.unknownLocation)
 
+    c:bound.Call => //T-Invk
+        val recType = getType(c.receiver, gamma)
+        val unfold:types.UnfoldedType = unfoldType(recType, gamma)
+        val pred = ((b:DeclType) =>
+            val z = match b:
+                da:types.DefType => c.name == da.name.name && types.equalType(getType(c.arg,gamma), da.argTyp)
+                default => false
+            z
+        )
+        val meth = llist.find[DeclType](unfold.decls, pred).get()
+        match meth:
+            da:types.DefType => da.retTyp
+            default => error.report("method not found",error.unknownLocation)
+
     s:bound.Seq => typeSeq(s.exps,gamma)
 
-    i:bound.Integer => types.NominalType(types.Binding("Int",types.Counter())) //wrong--fix this rule
+    i:bound.Integer => 
+        val pred = ((b:DeclType) =>
+            val z = match b:
+                tt:types.TypeType => tt.name.name == "Int"
+                default => false
+            z
+        )
+        val t = llist.find[DeclType](gamma, pred).get()  
+        match t:
+            tt:types.TypeType => types.NominalType(tt.name)
+            default => error.report("aaa",error.unknownLocation)
 
     default => error.report("type error: not implemented yet",error.unknownLocation)
 

--- a/selfhost/wyvernParser.wyv
+++ b/selfhost/wyvernParser.wyv
@@ -18,6 +18,9 @@ val grammar: parsing.Grammar = ~
            | %def %identifier %lparen %identifier %rparen %eq ExprLambda : a:Dyn => raw.Val(a.get(1).value, raw.Lambda(a.get(3).value, a.get(6)))
            | %type %identifier %colon %block                             : a:Dyn => raw.TypeDecl(a.get(1).value, a.get(3).value)
            | %val %identifier %colon Type                                : a:Dyn => raw.ValType(a.get(1).value, a.get(3))
+           | %def %identifier %lparen %identifier %colon Type %rparen %colon Type : a:Dyn => raw.DefDecl(a.get(1).value, a.get(3).value, a.get(5), a.get(8))
+           | %def %plus %lparen %identifier %colon Type %rparen %colon Type  : a:Dyn => raw.DefDecl("+", a.get(3).value, a.get(5), a.get(8))
+           | %def %minus %lparen %identifier %colon Type %rparen %colon Type : a:Dyn => raw.DefDecl("-", a.get(3).value, a.get(5), a.get(8))
 
     Type  -> %identifier                                  : a:Dyn => a.get(0).value
            
@@ -25,13 +28,13 @@ val grammar: parsing.Grammar = ~
                 | %identifier %darrow ExprLambda          : a:Dyn => raw.Lambda(a.get(0).value, a.get(2))
 
     ExprAddSub -> ExprMultDiv                             : a:Dyn => a.get(0)
-                | ExprAddSub %plus ExprMultDiv            : a:Dyn => raw.Call(a.get(0),"_PLUS_",a.get(2))
-                | ExprAddSub %minus ExprMultDiv           : a:Dyn => raw.Call(a.get(0),"_HYPHEN_",a.get(2))
+                | ExprAddSub %plus ExprMultDiv            : a:Dyn => raw.Call(a.get(0),"+",a.get(2))
+                | ExprAddSub %minus ExprMultDiv           : a:Dyn => raw.Call(a.get(0),"-",a.get(2))
 
     ExprMultDiv -> ExprAppl                               : a:Dyn => a.get(0)
-                 | ExprMultDiv %times ExprAppl            : a:Dyn => raw.Call(a.get(0),"_TIMES_",a.get(2))
-                 | ExprMultDiv %divide ExprAppl           : a:Dyn => raw.Call(a.get(0),"_DIVIDE_",a.get(2))
-                 | ExprMultDiv %mod ExprAppl              : a:Dyn => raw.Call(a.get(0),"_MOD_",a.get(2))
+                 | ExprMultDiv %times ExprAppl            : a:Dyn => raw.Call(a.get(0),"*",a.get(2))
+                 | ExprMultDiv %divide ExprAppl           : a:Dyn => raw.Call(a.get(0),"/",a.get(2))
+                 | ExprMultDiv %mod ExprAppl              : a:Dyn => raw.Call(a.get(0),"%",a.get(2))
 
     ExprAppl -> ExprUnary                                 : a:Dyn => a.get(0)
               | ExprAppl Primary                          : a:Dyn => raw.App(a.get(0), a.get(1))


### PR DESCRIPTION
I changed the _PLUS_, etc to be "+", "-" in the parser. This means a bunch of cases for each operator for member function declarations need to be added, though.
I'm wondering if the name in bound.Call.name should actually be a Binding instead of a string? Although I'm thinking it would difficult to determine which binding to give it (when constructing the bound.Call expression in binding.wyv), since in the context, there could be multiple bindings to function declarations with the same name.